### PR TITLE
Move spec proxy behavior to optional modifiers.

### DIFF
--- a/header/forwarded_modifier.go
+++ b/header/forwarded_modifier.go
@@ -1,0 +1,49 @@
+// Copyright 2015 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package header
+
+import (
+	"net"
+	"net/http"
+
+	"github.com/google/martian"
+)
+
+// NewForwardedModifier sets the X-Forwarded-For and X-Forwarded-Proto headers.
+//
+// If X-Forwarded-For is already present, the client IP is appended to
+// the existing value.
+//
+// TODO: Support "Forwarded" header.
+// see: http://tools.ietf.org/html/rfc7239
+func NewForwardedModifier() martian.RequestModifier {
+	return martian.RequestModifierFunc(
+		func(ctx *martian.Context, req *http.Request) error {
+			req.Header.Set("X-Forwarded-Proto", req.URL.Scheme)
+
+			xff, _, err := net.SplitHostPort(req.RemoteAddr)
+			if err != nil {
+				xff = req.RemoteAddr
+			}
+
+			if v := req.Header.Get("X-Forwarded-For"); v != "" {
+				xff = v + ", " + xff
+			}
+
+			req.Header.Set("X-Forwarded-For", xff)
+
+			return nil
+		})
+}

--- a/header/forwarded_modifier_test.go
+++ b/header/forwarded_modifier_test.go
@@ -1,0 +1,56 @@
+// Copyright 2015 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package header
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/google/martian"
+)
+
+func TestSetForwardHeaders(t *testing.T) {
+	xfp := "X-Forwarded-Proto"
+	xff := "X-Forwarded-For"
+
+	m := NewForwardedModifier()
+	req, err := http.NewRequest("GET", "http://martian.local", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest(): got %v, want no error", err)
+	}
+	req.RemoteAddr = "10.0.0.1:8112"
+
+	if m.ModifyRequest(martian.NewContext(), req); err != nil {
+		t.Fatalf("ModifyRequest(): got %v, want no error", err)
+	}
+
+	if got, want := req.Header.Get(xfp), "http"; got != want {
+		t.Errorf("req.Header.Get(%q): got %q, want %q", xfp, got, want)
+	}
+	if got, want := req.Header.Get(xff), "10.0.0.1"; got != want {
+		t.Errorf("req.Header.Get(%q): got %q, want %q", xff, got, want)
+	}
+
+	// Test with existing X-Forwarded-For.
+	req.RemoteAddr = "12.12.12.12"
+
+	if m.ModifyRequest(martian.NewContext(), req); err != nil {
+		t.Fatalf("ModifyRequest(): got %v, want no error", err)
+	}
+
+	if got, want := req.Header.Get(xff), "10.0.0.1, 12.12.12.12"; got != want {
+		t.Errorf("req.Header.Get(%q): got %q, want %q", xff, got, want)
+	}
+}

--- a/header/framing_modifier.go
+++ b/header/framing_modifier.go
@@ -1,0 +1,79 @@
+// Copyright 2015 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package header
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/google/martian"
+)
+
+// NewBadFramingModifier makes a best effort to fix inconsistencies in the
+// request such as multiple Content-Lengths or the lack of Content-Length and
+// improper Transfer-Encoding. If it is unable to determine a proper resolution
+// it returns an error.
+//
+// http://tools.ietf.org/html/draft-ietf-httpbis-p1-messaging-14#section-3.3
+func NewBadFramingModifier() martian.RequestModifier {
+	return martian.RequestModifierFunc(
+		func(ctx *martian.Context, req *http.Request) error {
+			cls := req.Header["Content-Length"]
+			if len(cls) > 0 {
+				var length string
+
+				// Iterate over all Content-Length headers, splitting any we find with
+				// commas, and check that all Content-Lengths are equal.
+				for _, ls := range cls {
+					for _, l := range strings.Split(ls, ",") {
+						// First length, set it as the canonical Content-Length.
+						if length == "" {
+							length = strings.TrimSpace(l)
+							continue
+						}
+
+						// Mismatched Content-Lengths.
+						if length != strings.TrimSpace(l) {
+							return fmt.Errorf(`bad request framing: multiple mismatched "Content-Length" headers: %v`, cls)
+						}
+					}
+				}
+
+				// All Content-Lengths are equal, remove extras and set it to the
+				// canonical value.
+				req.Header.Set("Content-Length", length)
+			}
+
+			tes := req.Header["Transfer-Encoding"]
+			if len(tes) > 0 {
+				// Extract the last Transfer-Encoding value, and split on commas.
+				last := strings.Split(tes[len(tes)-1], ",")
+
+				// Check that the last, potentially comma-delimited, value is
+				// "chunked", else we have no way to determine when the request is
+				// finished.
+				if strings.TrimSpace(last[len(last)-1]) != "chunked" {
+					return fmt.Errorf(`bad request framing: "Transfer-Encoding" header is present, but does not end in "chunked"`)
+				}
+
+				// Transfer-Encoding "chunked" takes precedence over
+				// Content-Length.
+				req.Header.Del("Content-Length")
+			}
+
+			return nil
+		})
+}

--- a/header/framing_modifier_test.go
+++ b/header/framing_modifier_test.go
@@ -1,0 +1,67 @@
+// Copyright 2015 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package header
+
+import (
+	"net/http"
+	"reflect"
+	"testing"
+
+	"github.com/google/martian"
+)
+
+func TestBadFramingMultipleContentLengths(t *testing.T) {
+	m := NewBadFramingModifier()
+	req, err := http.NewRequest("GET", "/", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest(): got %v, want no error", err)
+	}
+	req.Header["Content-Length"] = []string{"42", "42, 42"}
+
+	if err := m.ModifyRequest(martian.NewContext(), req); err != nil {
+		t.Errorf("ModifyRequest(): got %v, want no error", err)
+	}
+	if got, want := req.Header["Content-Length"], []string{"42"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("req.Header[%q]: got %v, want %v", "Content-Length", got, want)
+	}
+
+	req.Header["Content-Length"] = []string{"42", "32, 42"}
+	if err := m.ModifyRequest(martian.NewContext(), req); err == nil {
+		t.Error("ModifyRequest(): got nil, want error")
+	}
+}
+
+func TestBadFramingTransferEncodingAndContentLength(t *testing.T) {
+	m := NewBadFramingModifier()
+	req, err := http.NewRequest("GET", "/", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest(): got %v, want no error", err)
+	}
+	req.Header["Transfer-Encoding"] = []string{"gzip, chunked"}
+	req.Header["Content-Length"] = []string{"42"}
+
+	if err := m.ModifyRequest(martian.NewContext(), req); err != nil {
+		t.Errorf("ModifyRequest(): got %v, want no error", err)
+	}
+	if _, ok := req.Header["Content-Length"]; ok {
+		t.Fatalf("req.Header[%q]: got ok, want !ok", "Content-Length")
+	}
+
+	req.Header.Set("Transfer-Encoding", "gzip, identity")
+	req.Header.Del("Content-Length")
+	if err := m.ModifyRequest(martian.NewContext(), req); err == nil {
+		t.Error("ModifyRequest(): got nil, want error")
+	}
+}

--- a/header/hopbyhop_modifier.go
+++ b/header/hopbyhop_modifier.go
@@ -1,0 +1,75 @@
+// Copyright 2015 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package header
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/google/martian"
+)
+
+// Hop-by-hop headers as defined by RFC2616.
+//
+// http://tools.ietf.org/html/draft-ietf-httpbis-p1-messaging-14#section-7.1.3.1
+var HopByHopHeaders = []string{
+	"Connection",
+	"Keep-Alive",
+	"Proxy-Authenticate",
+	"Proxy-Authorization",
+	"Te",
+	"Trailer",
+	"Transfer-Encoding",
+	"Upgrade",
+}
+
+type hopByHopModifier struct{}
+
+// NewHopByHopModifier removes Hop-By-Hop headers from requests and
+// responses.
+func NewHopByHopModifier() martian.RequestResponseModifier {
+	return &hopByHopModifier{}
+}
+
+// ModifyRequest removes all hop-by-hop headers defined by RFC2616 as
+// well as any additional hop-by-hop headers specified in the
+// Connection header.
+func (m *hopByHopModifier) ModifyRequest(ctx *martian.Context, req *http.Request) error {
+	removeHopByHopHeaders(req.Header)
+	return nil
+}
+
+// ModifyResponse removes all hop-by-hop headers defined by RFC2616 as
+// well as any additional hop-by-hop headers specified in the
+// Connection header.
+func (m *hopByHopModifier) ModifyResponse(ctx *martian.Context, res *http.Response) error {
+	removeHopByHopHeaders(res.Header)
+	return nil
+}
+
+func removeHopByHopHeaders(header http.Header) {
+	// Additional hop-by-hop headers may be specified in `Connection` headers.
+	// http://tools.ietf.org/html/draft-ietf-httpbis-p1-messaging-14#section-9.1
+	for _, vs := range header["Connection"] {
+		for _, v := range strings.Split(vs, ",") {
+			k := http.CanonicalHeaderKey(strings.TrimSpace(v))
+			header.Del(k)
+		}
+	}
+
+	for _, k := range HopByHopHeaders {
+		header.Del(k)
+	}
+}

--- a/header/hopbyhop_modifier_test.go
+++ b/header/hopbyhop_modifier_test.go
@@ -1,0 +1,80 @@
+// Copyright 2015 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package header
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/google/martian"
+	"github.com/google/martian/proxyutil"
+)
+
+func TestRemoveHopByHopHeaders(t *testing.T) {
+	m := NewHopByHopModifier()
+	req, err := http.NewRequest("GET", "/", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest(): got %v, want no error", err)
+	}
+	hs := http.Header{
+		// Additional hop-by-hop headers are listed in the
+		// Connection header.
+		"Connection": []string{
+			"X-Connection",
+			"X-Hop-By-Hop, close",
+		},
+
+		// RFC hop-by-hop headers.
+		"Keep-Alive":          []string{},
+		"Proxy-Authenticate":  []string{},
+		"Proxy-Authorization": []string{},
+		"Te":                []string{},
+		"Trailer":           []string{},
+		"Transfer-Encoding": []string{},
+		"Upgrade":           []string{},
+
+		// Hop-by-hop headers listed in the Connection header.
+		"X-Connection": []string{},
+		"X-Hop-By-Hop": []string{},
+
+		// End-to-end header that should not be removed.
+		"X-End-To-End": []string{},
+	}
+
+	req.Header = hs
+	if err := m.ModifyRequest(martian.NewContext(), req); err != nil {
+		t.Fatalf("ModifyRequest(): got %v, want no error", err)
+	}
+
+	if got, want := len(req.Header), 1; got != want {
+		t.Fatalf("len(req.Header): got %d, want %d", got, want)
+	}
+	if _, ok := req.Header["X-End-To-End"]; !ok {
+		t.Errorf("req.Header[%q]: got !ok, want ok", "X-End-To-End")
+	}
+
+	res := proxyutil.NewResponse(200, nil, req)
+	res.Header = hs
+	if err := m.ModifyResponse(martian.NewContext(), res); err != nil {
+		t.Fatalf("ModifyResponse(): got %v, want no error", err)
+	}
+
+	if got, want := len(res.Header), 1; got != want {
+		t.Fatalf("len(res.Header): got %d, want %d", got, want)
+	}
+	if _, ok := res.Header["X-End-To-End"]; !ok {
+		t.Errorf("res.Header[%q]: got !ok, want ok", "X-End-To-End")
+	}
+}

--- a/header/via_modifier.go
+++ b/header/via_modifier.go
@@ -1,0 +1,39 @@
+// Copyright 2015 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package header
+
+import (
+	"net/http"
+
+	"github.com/google/martian"
+)
+
+// NewViaModifier sets the Via header.
+//
+// If Via is already present, via is appended to the existing value.
+//
+// http://tools.ietf.org/html/draft-ietf-httpbis-p1-messaging-14#section-9.9
+func NewViaModifier(via string) martian.RequestModifier {
+	return martian.RequestModifierFunc(
+		func(ctx *martian.Context, req *http.Request) error {
+			if v := req.Header.Get("Via"); v != "" {
+				via = v + ", " + via
+			}
+
+			req.Header.Set("Via", via)
+
+			return nil
+		})
+}

--- a/header/via_modifier_test.go
+++ b/header/via_modifier_test.go
@@ -1,0 +1,45 @@
+// Copyright 2015 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package header
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/google/martian"
+)
+
+func TestViaModifier(t *testing.T) {
+	m := NewViaModifier("1.1 martian")
+	req, err := http.NewRequest("GET", "/", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest(): got %v, want no error", err)
+	}
+
+	if err := m.ModifyRequest(martian.NewContext(), req); err != nil {
+		t.Fatalf("ModifyRequest(): got %v, want no error", err)
+	}
+	if got, want := req.Header.Get("Via"), "1.1 martian"; got != want {
+		t.Errorf("req.Header.Get(%q): got %q, want %q", "Via", got, want)
+	}
+
+	req.Header.Set("Via", "1.0 alpha")
+	if err := m.ModifyRequest(martian.NewContext(), req); err != nil {
+		t.Fatalf("ModifyRequest(): got %v, want no error", err)
+	}
+	if got, want := req.Header.Get("Via"), "1.0 alpha, 1.1 martian"; got != want {
+		t.Errorf("req.Header.Get(%q): got %q, want %q", "Via", got, want)
+	}
+}

--- a/martianhttp/martianhttp.go
+++ b/martianhttp/martianhttp.go
@@ -37,6 +37,22 @@ func NewModifier() *Modifier {
 	return &Modifier{}
 }
 
+// SetRequestModifier sets the request modifier.
+func (m *Modifier) SetRequestModifier(reqmod martian.RequestModifier) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.reqmod = reqmod
+}
+
+// SetResponseModifier sets the response modifier.
+func (m *Modifier) SetResponseModifier(resmod martian.ResponseModifier) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.resmod = resmod
+}
+
 // ModifyRequest runs reqmod.
 func (m *Modifier) ModifyRequest(ctx *martian.Context, req *http.Request) error {
 	m.mu.RLock()
@@ -96,7 +112,7 @@ func (m *Modifier) ResetRequestVerifications() {
 	}
 }
 
-// ResetResponseVerifications resets verifications on resdmo, iff resmod is a
+// ResetResponseVerifications resets verifications on resmod, iff resmod is a
 // ResponseVerifier.
 func (m *Modifier) ResetResponseVerifications() {
 	m.mu.RLock()

--- a/martianhttp/martianhttp_test.go
+++ b/martianhttp/martianhttp_test.go
@@ -45,11 +45,11 @@ func TestModifyRequest(t *testing.T) {
 	m := NewModifier()
 
 	var modRun bool
-	m.reqmod = martian.RequestModifierFunc(
+	m.SetRequestModifier(martian.RequestModifierFunc(
 		func(*martian.Context, *http.Request) error {
 			modRun = true
 			return nil
-		})
+		}))
 
 	req, err := http.NewRequest("GET", "http://example.com", nil)
 	if err != nil {
@@ -68,11 +68,11 @@ func TestModifyResponse(t *testing.T) {
 	m := NewModifier()
 
 	var modRun bool
-	m.resmod = martian.ResponseModifierFunc(
+	m.SetResponseModifier(martian.ResponseModifierFunc(
 		func(*martian.Context, *http.Response) error {
 			modRun = true
 			return nil
-		})
+		}))
 
 	res := proxyutil.NewResponse(200, nil, nil)
 	if err := m.ModifyResponse(martian.NewContext(), res); err != nil {
@@ -104,9 +104,9 @@ func TestVerifyRequests(t *testing.T) {
 	m := NewModifier()
 	verr := fmt.Errorf("request verification failure")
 
-	m.reqmod = &verify.TestVerifier{
+	m.SetRequestModifier(&verify.TestVerifier{
 		RequestError: verr,
-	}
+	})
 
 	if err := m.VerifyRequests(); err != verr {
 		t.Errorf("VerifyRequests(): got %v, want %v", err, verr)
@@ -125,9 +125,9 @@ func TestVerifyResponses(t *testing.T) {
 	m := NewModifier()
 	verr := fmt.Errorf("response verification failure")
 
-	m.resmod = &verify.TestVerifier{
+	m.SetResponseModifier(&verify.TestVerifier{
 		ResponseError: verr,
-	}
+	})
 
 	if err := m.VerifyResponses(); err != verr {
 		t.Errorf("VerifyResponses(): got %v, want %v", err, verr)

--- a/proxyutil/proxyutil.go
+++ b/proxyutil/proxyutil.go
@@ -19,34 +19,12 @@ package proxyutil
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"strings"
 )
-
-// ErrBadFraming is an error returned when it is impossible to determine how to
-// properly terminate a request. This often occurs becaue of conflicting
-// Content-Length headers or a non-chunked Transfer-Encoding without a
-// Content-Length.
-var ErrBadFraming = errors.New("bad request framing")
-
-// Hop-by-hop headers as defined by RFC2616.
-//
-// http://tools.ietf.org/html/draft-ietf-httpbis-p1-messaging-14#section-7.1.3.1
-var HopByHopHeaders = []string{
-	"Connection",
-	"Keep-Alive",
-	"Proxy-Authenticate",
-	"Proxy-Authorization",
-	"Te",
-	"Trailer",
-	"Transfer-Encoding",
-	"Upgrade",
-}
 
 // NewResponse builds new HTTP responses.
 // If body is nil, an empty byte.Buffer will be provided to be consistent with
@@ -62,14 +40,14 @@ func NewResponse(code int, body io.Reader, req *http.Request) *http.Response {
 	}
 
 	return &http.Response{
-		StatusCode:	code,
-		Status:		fmt.Sprintf("%d %s", code, http.StatusText(code)),
-		Proto:		"HTTP/1.1",
-		ProtoMajor:	1,
-		ProtoMinor:	1,
-		Header:		http.Header{},
-		Body:		rc,
-		Request:	req,
+		StatusCode: code,
+		Status:     fmt.Sprintf("%d %s", code, http.StatusText(code)),
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Header:     http.Header{},
+		Body:       rc,
+		Request:    req,
 	}
 }
 
@@ -80,108 +58,4 @@ func NewErrorResponse(code int, err error, req *http.Request) *http.Response {
 	res.ContentLength = int64(len(err.Error()))
 
 	return res
-}
-
-// RemoveHopByHopHeaders removes all hop-by-hop headers defined
-// by RFC2616 as well as any additional hop-by-hop headers
-// specified in the Connection header.
-func RemoveHopByHopHeaders(header http.Header) {
-	// Additional hop-by-hop headers may be specified in `Connection` headers.
-	// http://tools.ietf.org/html/draft-ietf-httpbis-p1-messaging-14#section-9.1
-	for _, vs := range header["Connection"] {
-		for _, v := range strings.Split(vs, ",") {
-			k := http.CanonicalHeaderKey(strings.TrimSpace(v))
-			header.Del(k)
-		}
-	}
-
-	for _, k := range HopByHopHeaders {
-		header.Del(k)
-	}
-}
-
-// SetForwardedHeaders sets the X-Fowarded-Proto and
-// X-Forwarded-For headers for the outgoing request.
-//
-// If X-Forwarded-For is already present, the client IP is appended to the
-// existing value.
-func SetForwardedHeaders(req *http.Request) {
-	req.Header.Set("X-Forwarded-Proto", req.URL.Scheme)
-
-	xff, _, err := net.SplitHostPort(req.RemoteAddr)
-	if err != nil {
-		xff = req.RemoteAddr
-	}
-
-	if v := req.Header.Get("X-Forwarded-For"); v != "" {
-		xff = v + ", " + xff
-	}
-
-	req.Header.Set("X-Forwarded-For", xff)
-}
-
-// SetViaHeader sets the Via header.
-//
-// If Via is already present, via is appended to
-// the existing value.
-//
-// http://tools.ietf.org/html/draft-ietf-httpbis-p1-messaging-14#section-9.9
-func SetViaHeader(header http.Header, via string) {
-	if v := header.Get("Via"); v != "" {
-		via = v + ", " + via
-	}
-
-	header.Set("Via", via)
-}
-
-// FixBadFraming makes a best effort to fix inconsistencies in the request such
-// as multiple Content-Lengths or the lack of Content-Length and improper
-// Transfer-Encoding. If it is unable to determine a proper resolution it
-// returns ErrBadFraming.
-//
-// http://tools.ietf.org/html/draft-ietf-httpbis-p1-messaging-14#section-3.3
-func FixBadFraming(header http.Header) error {
-	cls := header["Content-Length"]
-	if len(cls) > 0 {
-		var length string
-
-		// Iterate over all Content-Length headers, splitting any we find with
-		// commas, and check that all Content-Lengths are equal.
-		for _, ls := range cls {
-			for _, l := range strings.Split(ls, ",") {
-				// First length, set it as the canonical Content-Length.
-				if length == "" {
-					length = strings.TrimSpace(l)
-					continue
-				}
-
-				// Mismatched Content-Lengths.
-				if length != strings.TrimSpace(l) {
-					return ErrBadFraming
-				}
-			}
-		}
-
-		// All Content-Lengths are equal, remove extras and set it to the canonical
-		// value.
-		header.Set("Content-Length", length)
-	}
-
-	tes := header["Transfer-Encoding"]
-	if len(tes) > 0 {
-		// Extract the last Transfer-Encoding value, and split on commas.
-		last := strings.Split(tes[len(tes)-1], ",")
-
-		// Check that the last, potentially comma-delimited, value is "chunked",
-		// else we have no way to determine when the request is finished.
-		if strings.TrimSpace(last[len(last)-1]) != "chunked" {
-			return ErrBadFraming
-		}
-
-		// Transfer-Encoding "chunked" takes precedence over
-		// Content-Length.
-		header.Del("Content-Length")
-	}
-
-	return nil
 }


### PR DESCRIPTION
HTTP proxies are required to implement certain functionality as per the
spec. However, some customers want to use Martian more as a transparent
proxy and would rather it not manipulate the request/response at all if
possible.

I have moved some of the core functionality such as checking for bad
framing and the removal of hop-by-hop headers to modifiers that will be
recommended, but not required.