### PR TITLE
proxy: Add in-proxy ServeMux.

### DIFF
--- a/log.go
+++ b/log.go
@@ -23,7 +23,7 @@ import (
 func Infof(format string, args ...interface{}) {
 	msg := fmt.Sprintf("INFO: %s", format)
 	if len(args) > 0 {
-		msg = fmt.Sprintf(format, args...)
+		msg = fmt.Sprintf(msg, args...)
 	}
 
 	log.Println(msg)
@@ -33,7 +33,7 @@ func Infof(format string, args ...interface{}) {
 func Debugf(format string, args ...interface{}) {
 	msg := fmt.Sprintf("DEBUG: %s", format)
 	if len(args) > 0 {
-		msg = fmt.Sprintf(format, args...)
+		msg = fmt.Sprintf(msg, args...)
 	}
 
 	log.Println(msg)
@@ -43,7 +43,7 @@ func Debugf(format string, args ...interface{}) {
 func Errorf(format string, args ...interface{}) {
 	msg := fmt.Sprintf("ERROR: %s", format)
 	if len(args) > 0 {
-		msg = fmt.Sprintf(format, args...)
+		msg = fmt.Sprintf(msg, args...)
 	}
 
 	log.Println(msg)

--- a/response_writer.go
+++ b/response_writer.go
@@ -1,0 +1,95 @@
+// Copyright 2015 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package martian
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httputil"
+)
+
+// responseWriter is a lightweight http.ResponseWriter designed to allow
+// Martian to support in-proxy endpoints.
+//
+// responseWriter does not support all of the functionality of the net/http
+// ResponseWriter; in particular, it does not sniff Content-Types.
+type responseWriter struct {
+	ow          io.Writer // original writer
+	w           io.Writer // current writer
+	hdr         http.Header
+	wroteHeader bool
+}
+
+// newResponseWriter returns a new http.ResponseWriter.
+func newResponseWriter(w io.Writer) *responseWriter {
+	return &responseWriter{
+		ow:  w,
+		w:   w,
+		hdr: http.Header{},
+	}
+}
+
+// Header returns the headers for the response writer.
+func (rw *responseWriter) Header() http.Header {
+	return rw.hdr
+}
+
+// Write writes b to the response body; if the header has yet to be written it
+// will write that before the body.
+func (rw *responseWriter) Write(b []byte) (int, error) {
+	if !rw.wroteHeader {
+		rw.WriteHeader(200)
+	}
+
+	return rw.w.Write(b)
+}
+
+// WriteHeader writes the status line and headers.
+func (rw *responseWriter) WriteHeader(status int) {
+	if rw.wroteHeader {
+		return
+	}
+	rw.wroteHeader = true
+
+	fmt.Fprintf(rw.w, "HTTP/1.1 %d %s\r\n", status, http.StatusText(status))
+
+	var chunked bool
+	if rw.hdr.Get("Content-Length") == "" {
+		rw.hdr.Set("Transfer-Encoding", "chunked")
+		chunked = true
+	}
+	rw.hdr.Write(rw.w)
+
+	rw.w.Write([]byte("\r\n"))
+
+	if chunked {
+		rw.w = httputil.NewChunkedWriter(rw.w)
+	}
+}
+
+// Close closes the underlying writer if it is also an io.Closer.
+func (rw *responseWriter) Close() error {
+	var err error
+
+	wc, ok := rw.w.(io.Closer)
+	if ok {
+		err = wc.Close()
+	}
+
+	rw.ow.Write([]byte("\r\n"))
+
+	return err
+}

--- a/response_writer_test.go
+++ b/response_writer_test.go
@@ -1,0 +1,102 @@
+// Copyright 2015 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package martian
+
+import (
+	"bufio"
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestResponseWriter(t *testing.T) {
+	buf := &bytes.Buffer{}
+
+	rw := newResponseWriter(buf)
+	rw.Header().Set("Martian-Response", "true")
+	rw.Header().Set("Content-Length", "12")
+
+	rw.Write([]byte("test "))
+
+	// This will be ignored.
+	rw.WriteHeader(400)
+
+	rw.Write([]byte("content"))
+
+	rw.Close()
+
+	res, err := http.ReadResponse(bufio.NewReader(buf), nil)
+	if err != nil {
+		t.Fatalf("http.ReadResponse(): got %v, want no error", err)
+	}
+	defer res.Body.Close()
+
+	if got, want := res.StatusCode, 200; got != want {
+		t.Errorf("res.StatusCode: got %d, want %d", got, want)
+	}
+	if got, want := res.ContentLength, int64(12); got != want {
+		t.Errorf("res.ContentLength: got %d, want %d", got, want)
+	}
+	if got, want := res.Header.Get("Martian-Response"), "true"; got != want {
+		t.Errorf("res.Header.Get(%q): got %q, want %q", "Martian-Response", got, want)
+	}
+
+	got, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		t.Fatalf("ioutil.ReadAll(): got %v, want no error", err)
+	}
+
+	if want := []byte("test content"); !bytes.Equal(got, want) {
+		t.Errorf("res.Body: got %q, want %q", got, want)
+	}
+}
+
+func TestResponseWriterChunkedEncoding(t *testing.T) {
+	buf := &bytes.Buffer{}
+
+	rw := newResponseWriter(buf)
+	rw.Header().Set("Martian-Response", "true")
+
+	rw.Write([]byte("test "))
+	rw.Write([]byte("content"))
+	rw.Close()
+
+	res, err := http.ReadResponse(bufio.NewReader(buf), nil)
+	if err != nil {
+		t.Fatalf("http.ReadResponse(): got %v, want no error", err)
+	}
+	defer res.Body.Close()
+
+	if got, want := res.StatusCode, 200; got != want {
+		t.Errorf("res.StatusCode: got %d, want %d", got, want)
+	}
+	if got, want := res.TransferEncoding, []string{"chunked"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("res.TransferEncoding: got %v, want %v", got, want)
+	}
+	if got, want := res.Header.Get("Martian-Response"), "true"; got != want {
+		t.Errorf("res.Header.Get(%q): got %q, want %q", "Martian-Response", got, want)
+	}
+
+	got, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		t.Fatalf("ioutil.ReadAll(): got %v, want no error", err)
+	}
+
+	if want := []byte("test content"); !bytes.Equal(got, want) {
+		t.Errorf("res.Body: got %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
This allows end users to easily configure Martian through Martian as
well as support heartbeats and other functionality.