### PR TITLE
log: separate logging from martian package.

### DIFF
--- a/cookie/cookie_modifier.go
+++ b/cookie/cookie_modifier.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/google/martian"
+	"github.com/google/martian/log"
 	"github.com/google/martian/parse"
 )
 
@@ -47,7 +48,7 @@ type modifierJSON struct {
 // ModifyRequest adds cookie to the request.
 func (m *modifier) ModifyRequest(req *http.Request) error {
 	req.AddCookie(m.cookie)
-	martian.Infof("%s: add cookie: %s", req.URL, m.cookie)
+	log.Debugf("cookie: %s: append request cookie: %s", req.URL, m.cookie)
 
 	return nil
 }
@@ -55,7 +56,7 @@ func (m *modifier) ModifyRequest(req *http.Request) error {
 // ModifyResponse sets cookie on the response.
 func (m *modifier) ModifyResponse(res *http.Response) error {
 	res.Header.Add("Set-Cookie", m.cookie.String())
-	martian.Infof("%s: add cookie: %s", res.Request.URL, m.cookie)
+	log.Debugf("cookie: %s: append response cookie: %s", res.Request.URL, m.cookie)
 
 	return nil
 }

--- a/examples/main.go
+++ b/examples/main.go
@@ -185,7 +185,7 @@ import (
 
 	_ "github.com/google/martian/body"
 	_ "github.com/google/martian/cookie"
-	_ "github.com/google/martian/log"
+	_ "github.com/google/martian/martianlog"
 	_ "github.com/google/martian/martianurl"
 	_ "github.com/google/martian/method"
 	_ "github.com/google/martian/pingback"

--- a/log/log.go
+++ b/log/log.go
@@ -12,14 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package martian
+// Package log provides a universal logger for martian packages.
+package log
 
 import (
 	"fmt"
 	"log"
 )
 
-// Infof logs an info message with caller information.
+// Infof logs an info message.
 func Infof(format string, args ...interface{}) {
 	msg := fmt.Sprintf("INFO: %s", format)
 	if len(args) > 0 {
@@ -29,7 +30,7 @@ func Infof(format string, args ...interface{}) {
 	log.Println(msg)
 }
 
-// Debugf logs a debug message with caller information.
+// Debugf logs a debug message.
 func Debugf(format string, args ...interface{}) {
 	msg := fmt.Sprintf("DEBUG: %s", format)
 	if len(args) > 0 {
@@ -39,7 +40,7 @@ func Debugf(format string, args ...interface{}) {
 	log.Println(msg)
 }
 
-// Errorf logs an error message with caller information.
+// Errorf logs an error message.
 func Errorf(format string, args ...interface{}) {
 	msg := fmt.Sprintf("ERROR: %s", format)
 	if len(args) > 0 {

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -1,0 +1,46 @@
+// Copyright 2015 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	stdlog "log"
+)
+
+func TestLog(t *testing.T) {
+	buf := new(bytes.Buffer)
+
+	stdlog.SetOutput(buf)
+	defer stdlog.SetOutput(os.Stdout)
+
+	Infof("log: %s test", "info")
+	if got, want := buf.String(), "INFO: log: info test\n"; !strings.HasSuffix(got, want) {
+		t.Errorf("Infof(): got %q, want to contain %q", got, want)
+	}
+
+	Debugf("log: %s test", "debug")
+	if got, want := buf.String(), "DEBUG: log: debug test\n"; !strings.HasSuffix(got, want) {
+		t.Errorf("Debugf(): got %q, want to contain %q", got, want)
+	}
+
+	Errorf("log: %s test", "error")
+	if got, want := buf.String(), "ERROR: log: error test\n"; !strings.HasSuffix(got, want) {
+		t.Errorf("Errorf(): got %q, want to contain %q", got, want)
+	}
+}

--- a/martianhttp/martianhttp.go
+++ b/martianhttp/martianhttp.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 
 	"github.com/google/martian"
+	"github.com/google/martian/log"
 	"github.com/google/martian/parse"
 	"github.com/google/martian/verify"
 )
@@ -141,7 +142,7 @@ func (m *Modifier) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	body, err := ioutil.ReadAll(req.Body)
 	if err != nil {
 		http.Error(rw, err.Error(), 500)
-		martian.Errorf("error reading request body: %v", err)
+		log.Errorf("error reading request body: %v", err)
 		return
 	}
 	req.Body.Close()
@@ -149,7 +150,7 @@ func (m *Modifier) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	r, err := parse.FromJSON(body)
 	if err != nil {
 		http.Error(rw, err.Error(), 400)
-		martian.Errorf("error parsing JSON: %v", err)
+		log.Errorf("error parsing JSON: %v", err)
 		return
 	}
 

--- a/martianlog/logger.go
+++ b/martianlog/logger.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package log provides a Martian modifier that logs the request and response.
-package log
+// Package martianlog provides a Martian modifier that logs the request and response.
+package martianlog
 
 import (
 	"bytes"
@@ -23,7 +23,7 @@ import (
 	"net/http/httputil"
 	"strings"
 
-	"github.com/google/martian"
+	"github.com/google/martian/log"
 	"github.com/google/martian/parse"
 )
 
@@ -47,7 +47,7 @@ func init() {
 func NewLogger() *Logger {
 	return &Logger{
 		log: func(line string) {
-			martian.Infof(line)
+			log.Infof(line)
 		},
 	}
 }

--- a/martianlog/logger_test.go
+++ b/martianlog/logger_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package log
+package martianlog
 
 import (
 	"fmt"

--- a/martiantest/martiantest.go
+++ b/martiantest/martiantest.go
@@ -21,7 +21,8 @@ import (
 	"sync/atomic"
 )
 
-// Modifier keeps track of the number of requests and responses it has modified and can be configured to return errors or run custom functions.
+// Modifier keeps track of the number of requests and responses it has modified
+// and can be configured to return errors or run custom functions.
 type Modifier struct {
 	reqcount int32 // atomic
 	rescount int32 // atomic

--- a/mitm/mitm.go
+++ b/mitm/mitm.go
@@ -26,11 +26,12 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"errors"
-	"log"
 	"math/big"
 	"net"
 	"sync"
 	"time"
+
+	"github.com/google/martian/log"
 )
 
 // MaxSerialNumber is the upper boundary that is used to create unique serial
@@ -201,7 +202,7 @@ func (c *Config) cert(hostname string) (*tls.Certificate, error) {
 	c.certmu.RUnlock()
 
 	if ok {
-		log.Printf("mitm: cache hit for %s\n", hostname)
+		log.Debugf("mitm: cache hit for %s", hostname)
 
 		// Check validity of the certificate for hostname match, expiry, etc. In
 		// particular, if the cached certificate has expired, create a new one.
@@ -212,10 +213,10 @@ func (c *Config) cert(hostname string) (*tls.Certificate, error) {
 			return tlsc, nil
 		}
 
-		log.Printf("mitm: invalid certificate in cache for %s\n", hostname)
+		log.Debugf("mitm: invalid certificate in cache for %s", hostname)
 	}
 
-	log.Printf("mitm: cache miss for %s\n", hostname)
+	log.Debugf("mitm: cache miss for %s", hostname)
 
 	serial, err := rand.Int(rand.Reader, MaxSerialNumber)
 	if err != nil {

--- a/noop.go
+++ b/noop.go
@@ -14,7 +14,11 @@
 
 package martian
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/google/martian/log"
+)
 
 type noopModifier struct {
 	id string
@@ -29,12 +33,12 @@ func Noop(id string) RequestResponseModifier {
 
 // ModifyRequest logs a debug line.
 func (nm *noopModifier) ModifyRequest(*http.Request) error {
-	Debugf("%s: no request modifier configured", nm.id)
+	log.Debugf("%s: no request modifier configured", nm.id)
 	return nil
 }
 
 // ModifyResponse logs a debug line.
 func (nm *noopModifier) ModifyResponse(*http.Response) error {
-	Debugf("%s: no response modifier configured", nm.id)
+	log.Debugf("%s: no response modifier configured", nm.id)
 	return nil
 }

--- a/verify/verify_handlers.go
+++ b/verify/verify_handlers.go
@@ -18,7 +18,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/google/martian"
+	"github.com/google/martian/log"
 )
 
 // Handler is an http.Handler that returns the request and response
@@ -73,7 +73,7 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	if req.Method != "GET" {
 		rw.Header().Set("Allow", "GET")
 		rw.WriteHeader(405)
-		martian.Errorf("Method: %v not allowed for URL: %v. Use GET.", req.Method, req.URL)
+		log.Errorf("verify: invalid request method: %s", req.Method)
 		return
 	}
 
@@ -121,7 +121,7 @@ func (h *ResetHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	if req.Method != "POST" {
 		rw.Header().Set("Allow", "POST")
 		rw.WriteHeader(405)
-		martian.Errorf("Method: %v not allowed for URL: %v. Use GET.", req.Method, req.URL)
+		log.Errorf("verify: invalid request method: %s", req.Method)
 		return
 	}
 


### PR DESCRIPTION
The motivation for this change is to allow logging to be controlled from
a central package that won't ever cause cyclic dependencies. This was a
problem when attempting to use the logging functions in the mitm package
since the martian package depends on mitm.