### PR TITLE
messageview: move MessageView from proxyutil to its own package.

### DIFF
--- a/martianlog/logger_test.go
+++ b/martianlog/logger_test.go
@@ -118,11 +118,11 @@ func TestLoggerFromJSON(t *testing.T) {
 		t.Error("resmod.(*Logger); got !ok, want ok")
 	}
 
-	if !l.conf.HeadersOnly {
-		t.Error("l.conf.HeadersOnly: got false, want true")
+	if !l.headersOnly {
+		t.Error("l.headersOnly: got false, want true")
 	}
 
-	if !l.conf.Decode {
-		t.Error("l.conf.Decode: got false, want true")
+	if !l.decode {
+		t.Error("l.decode: got false, want true")
 	}
 }


### PR DESCRIPTION
Additionally, move the decode option to the reader itself rather than the MessageView. Allows a single MessageView to be read for both the decoded message for logging and as an exact copy.