### PR TITLE
har: add HAR logging package and API

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,34 @@ flag:
 
     $GOPATH/bin/proxy -v
 
-For logging of requests and responses a [logging modifier](https://github.com/google/martian/wiki/Modifier-Reference#logging) is available
-
 By default, Martian will be running on port 8080. The port can be specified via
 a flag:
 
     $GOPATH/bin/proxy -port=9999
+
+### Logging
+For logging of requests and responses a [logging
+modifier](https://github.com/google/martian/wiki/Modifier-Reference#logging) is
+available or [HAR](http://www.softwareishard.com/blog/har-12-spec/) logs are
+available if the `-har` flag is used.
+
+#### HAR Logging
+To enable HAR logging in Martian call the binary with the `-har` flag:
+
+    $GOPATH/bin/proxy -har
+
+If the `-har` flag has been enabled two HAR related endpoints will be
+available:
+
+    GET http://martian.proxy/har/logs
+
+Will retrieve the HAR log of all requests and responses seen by the proxy since
+the last reset.
+
+    DELETE http://martian.proxy/har/logs/reset
+
+Will reset the in-memory HAR log. Note that the log will grow unbounded unless
+it is periodically reset.
 
 ### Configure
 Once Martian is running, you need to configure its behavior. Without

--- a/har/har.go
+++ b/har/har.go
@@ -1,0 +1,520 @@
+// Copyright 2015 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package har collects HTTP requests and responses and stores them in HAR format.
+//
+// For more information on HAR, see:
+// https://w3c.github.io/web-performance/specs/HAR/Overview.html
+package har
+
+import (
+	"io"
+	"io/ioutil"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/martian"
+	"github.com/google/martian/log"
+	"github.com/google/martian/messageview"
+)
+
+// Logger maintains request and response log entries.
+type Logger struct {
+	creator *Creator
+
+	mu      sync.Mutex
+	entries map[string]*Entry
+}
+
+// HAR is the top level object of a HAR log.
+type HAR struct {
+	Log *Log `json:"log"`
+}
+
+// Log is the HAR HTTP request and response log.
+type Log struct {
+	// Version number of the HAR format.
+	Version string `json:"version"`
+	// Creator holds information about the log creator application.
+	Creator *Creator `json:"creator"`
+	// Entries is a list containing requests and responses.
+	Entries []*Entry `json:"entries"`
+}
+
+// Creator is the program responsible for generating the log.
+type Creator struct {
+	// Name of the log creator application.
+	Name string `json:"name"`
+	// Version of the log creator application.
+	Version string `json:"version"`
+}
+
+// Entry is a individual log entry for a request or response.
+type Entry struct {
+	// ID is the unique ID for the entry.
+	ID string `json:"_id"`
+	// StartedDateTime is the date and time stamp of the request start (ISO 8601).
+	StartedDateTime time.Time `json:"startedDateTime"`
+	// Time is the total elapsed time of the request in milliseconds.
+	Time int64 `json:"time"`
+	// Request contains the detailed information about the request.
+	Request *Request `json:"request"`
+	// Response contains the detailed information about the response.
+	Response *Response `json:"response,omitempty"`
+	// Cache contains information about a request coming from browser cache.
+	Cache *Cache `json:"cache"`
+	// Timings describes various phases within request-response round trip. All
+	// times are specified in milliseconds.
+	Timings *Timings `json:"timings"`
+}
+
+// Request holds data about an individual HTTP request.
+type Request struct {
+	// Method is the request method (GET, POST, ...).
+	Method string `json:"method"`
+	// URL is the absolute URL of the request (fragments are not included).
+	URL string `json:"url"`
+	// HTTPVersion is the Request HTTP version (HTTP/1.1).
+	HTTPVersion string `json:"httpVersion"`
+	// Cookies is a list of cookies.
+	Cookies []Cookie `json:"cookies"`
+	// Headers is a list of headers.
+	Headers []Header `json:"headers"`
+	// QueryString is a list of query parameters.
+	QueryString []QueryString `json:"queryString"`
+	// PostData is the posted data information.
+	PostData *PostData `json:"postData,omitempty"`
+	// HeaderSize is the Total number of bytes from the start of the HTTP request
+	// message until (and including) the double CLRF before the body. Set to -1
+	// if the info is not available.
+	HeadersSize int64 `json:"headersSize"`
+	// BodySize is the size of the request body (POST data payload) in bytes. Set
+	// to -1 if the info is not available.
+	BodySize int64 `json:"bodySize"`
+}
+
+// Response holds data about an individual HTTP response.
+type Response struct {
+	// Status is the response status code.
+	Status int `json:"status"`
+	// StatusText is the response status description.
+	StatusText string `json:"statusText"`
+	// HTTPVersion is the Response HTTP version (HTTP/1.1).
+	HTTPVersion string `json:"httpVersion"`
+	// Cookies is a list of cookies.
+	Cookies []Cookie `json:"cookies"`
+	// Headers is a list of headers.
+	Headers []Header `json:"headers"`
+	// Content contains the details of the response body.
+	Content *Content `json:"content"`
+	// RedirectURL is the target URL from the Location response header.
+	RedirectURL string `json:"redirectURL"`
+	// HeadersSize is the total number of bytes from the start of the HTTP
+	// request message until (and including) the double CLRF before the body.
+	// Set to -1 if the info is not available.
+	HeadersSize int64 `json:"headersSize"`
+	// BodySize is the size of the request body (POST data payload) in bytes. Set
+	// to -1 if the info is not available.
+	BodySize int64 `json:"bodySize"`
+}
+
+// Cache contains information about a request coming from browser cache.
+type Cache struct {
+	// Has no fields as they are not supported, but HAR requires the "cache"
+	// object to exist.
+}
+
+// Timings describes various phases within request-response round trip. All
+// times are specified in milliseconds
+type Timings struct {
+	// Send is the time required to send HTTP request to the server.
+	Send int64 `json:"send"`
+	// Wait is the time spent waiting for a response from the server.
+	Wait int64 `json:"wait"`
+	// Receive is the time required to read entire response from server or cache.
+	Receive int64 `json:"receive"`
+}
+
+// Cookie is the data about a cookie on a request or response.
+type Cookie struct {
+	// Name is the cookie name.
+	Name string `json:"name"`
+	// Value is the cookie value.
+	Value string `json:"value"`
+	// Path is the path pertaining to the cookie.
+	Path string `json:"path,omitempty"`
+	// Domain is the host of the cookie.
+	Domain string `json:"domain,omitempty"`
+	// Expires contains cookie expiration time.
+	Expires time.Time `json:"-"`
+	// Expires8601 contains cookie expiration time in ISO 8601 format.
+	Expires8601 string `json:"expires,omitempty"`
+	// HTTPOnly is set to true if the cookie is HTTP only, false otherwise.
+	HTTPOnly bool `json:"httpOnly,omitempty"`
+	// Secure is set to true if the cookie was transmitted over SSL, false
+	// otherwise.
+	Secure bool `json:"secure,omitempty"`
+}
+
+// Header is an HTTP request or response header.
+type Header struct {
+	// Name is the header name.
+	Name string `json:"name"`
+	// Value is the header value.
+	Value string `json:"value"`
+}
+
+// QueryString is a query string parameter on a request.
+type QueryString struct {
+	// Name is the query parameter name.
+	Name string `json:"name"`
+	// Value is the query parameter value.
+	Value string `json:"value"`
+}
+
+// PostData describes posted data on a request.
+type PostData struct {
+	// MimeType is the MIME type of the posted data.
+	MimeType string `json:"mimeType"`
+	// Params is a list of posted parameters (in case of URL encoded parameters).
+	Params []Param `json:"params"`
+	// Text contains the plain text posted data.
+	Text string `json:"text"`
+}
+
+// Param describes an individual posted parameter.
+type Param struct {
+	// Name of the posted parameter.
+	Name string `json:"name"`
+	// Value of the posted parameter.
+	Value string `json:"value,omitempty"`
+	// Filename of a posted file.
+	Filename string `json:"fileName,omitempty"`
+	// ContentType is the content type of a posted file.
+	ContentType string `json:"contentType,omitempty"`
+}
+
+// Content describes details about response content.
+type Content struct {
+	// Size is the length of the returned content in bytes. Should be equal to
+	// response.bodySize if there is no compression and bigger when the content
+	// has been compressed.
+	Size int64 `json:"size"`
+	// MimeType is the MIME type of the response text (value of the Content-Type
+	// response header).
+	MimeType string `json:"mimeType"`
+	// Text contains the response body sent from the server or loaded from the
+	// browser cache. This field is populated with textual content only. The text
+	// field is either HTTP decoded text or a encoded (e.g. "base64")
+	// representation of the response body. Leave out this field if the
+	// information is not available.
+	Text []byte `json:"text,omitempty"`
+	// Encoding used for response text field e.g "base64". Leave out this field
+	// if the text field is HTTP decoded (decompressed & unchunked), than
+	// trans-coded from its original character set into UTF-8.
+	Encoding string `json:"encoding,omitempty"`
+}
+
+// NewLogger returns a HAR logger using name and version as the Creator.
+func NewLogger(name, version string) *Logger {
+	return &Logger{
+		creator: &Creator{
+			Name:    name,
+			Version: version,
+		},
+		entries: make(map[string]*Entry),
+	}
+}
+
+// ModifyRequest logs requests.
+func (l *Logger) ModifyRequest(req *http.Request) error {
+	ctx := martian.Context(req)
+	id := ctx.ID()
+
+	return l.LogRequest(id, req)
+}
+
+// LogRequest logs the HTTP request with the given ID. The ID should be unique
+// per request/response pair.
+func (l *Logger) LogRequest(id string, req *http.Request) error {
+	hreq := &Request{
+		Method:      req.Method,
+		URL:         req.URL.String(),
+		HTTPVersion: req.Proto,
+		HeadersSize: -1,
+		BodySize:    req.ContentLength,
+		QueryString: []QueryString{},
+	}
+
+	hreq.Headers = headers(req.Header)
+	hreq.Cookies = cookies(req.Cookies())
+
+	for n, vs := range req.URL.Query() {
+		for _, v := range vs {
+			hreq.QueryString = append(hreq.QueryString, QueryString{
+				Name:  n,
+				Value: v,
+			})
+		}
+	}
+
+	pd, err := postData(req)
+	if err != nil {
+		return err
+	}
+	hreq.PostData = pd
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.entries[id] = &Entry{
+		ID:              id,
+		StartedDateTime: time.Now().UTC(),
+		Request:         hreq,
+		Cache:           &Cache{},
+		Timings:         &Timings{},
+	}
+
+	return nil
+}
+
+// ModifyResponse logs responses.
+func (l *Logger) ModifyResponse(res *http.Response) error {
+	ctx := martian.Context(res.Request)
+	id := ctx.ID()
+
+	return l.LogResponse(id, res)
+}
+
+// LogResponse logs an HTTP response, associating it with the previously-logged
+// HTTP request with the same ID.
+func (l *Logger) LogResponse(id string, res *http.Response) error {
+	hres := &Response{
+		HTTPVersion: res.Proto,
+		Status:      res.StatusCode,
+		StatusText:  http.StatusText(res.StatusCode),
+		HeadersSize: -1,
+		BodySize:    res.ContentLength,
+	}
+
+	if res.StatusCode >= 300 && res.StatusCode < 400 {
+		hres.RedirectURL = res.Header.Get("Location")
+	}
+
+	hres.Headers = headers(res.Header)
+	hres.Cookies = cookies(res.Cookies())
+
+	mv := messageview.New()
+	if err := mv.SnapshotResponse(res); err != nil {
+		return err
+	}
+
+	br, err := mv.BodyReader(messageview.Decode())
+	if err != nil {
+		return err
+	}
+
+	body, err := ioutil.ReadAll(br)
+	if err != nil {
+		return err
+	}
+
+	hres.Content = &Content{
+		Text:     body,
+		Encoding: "base64",
+		Size:     int64(len(body)),
+		MimeType: res.Header.Get("Content-Type"),
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if e, ok := l.entries[id]; ok {
+		e.Response = hres
+		e.Time = time.Since(e.StartedDateTime).Nanoseconds() / 1000000
+	}
+
+	return nil
+}
+
+// Export returns the in-memory log.
+func (l *Logger) Export() *HAR {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	es := make([]*Entry, 0, len(l.entries))
+	for _, e := range l.entries {
+		es = append(es, e)
+	}
+
+	sort.Sort(byRequestDate(es))
+
+	return &HAR{
+		Log: &Log{
+			Version: "1.2",
+			Creator: l.creator,
+			Entries: es,
+		},
+	}
+}
+
+// Reset clears the in-memory log of entries.
+func (l *Logger) Reset() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.entries = make(map[string]*Entry)
+}
+
+func cookies(cs []*http.Cookie) []Cookie {
+	hcs := make([]Cookie, 0, len(cs))
+
+	for _, c := range cs {
+		var expires string
+		if !c.Expires.IsZero() {
+			expires = c.Expires.Format(time.RFC3339)
+		}
+
+		hcs = append(hcs, Cookie{
+			Name:        c.Name,
+			Value:       c.Value,
+			Path:        c.Path,
+			Domain:      c.Domain,
+			HTTPOnly:    c.HttpOnly,
+			Secure:      c.Secure,
+			Expires:     c.Expires,
+			Expires8601: expires,
+		})
+	}
+
+	return hcs
+}
+
+func headers(hs http.Header) []Header {
+	hhs := make([]Header, 0, len(hs))
+
+	for n, vs := range hs {
+		hhs = append(hhs, Header{
+			Name:  n,
+			Value: strings.Join(vs, ", "),
+		})
+	}
+
+	return hhs
+}
+
+func postData(req *http.Request) (*PostData, error) {
+	// If the request has no body (no Content-Length and Transfer-Encoding isn't
+	// chunked), skip the post data.
+	if req.ContentLength <= 0 && len(req.TransferEncoding) == 0 {
+		return nil, nil
+	}
+
+	ct := req.Header.Get("Content-Type")
+	mt, ps, err := mime.ParseMediaType(ct)
+	if err != nil {
+		log.Errorf("har: cannot parse Content-Type header %q: %v", ct, err)
+		mt = ct
+	}
+
+	pd := &PostData{
+		MimeType: mt,
+		Params:   []Param{},
+	}
+
+	mv := messageview.New()
+	if err := mv.SnapshotRequest(req); err != nil {
+		return nil, err
+	}
+
+	br, err := mv.BodyReader()
+	if err != nil {
+		return nil, err
+	}
+
+	switch mt {
+	case "multipart/form-data":
+		mpr := multipart.NewReader(br, ps["boundary"])
+
+		for {
+			p, err := mpr.NextPart()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				return nil, err
+			}
+			defer p.Close()
+
+			body, err := ioutil.ReadAll(p)
+			if err != nil {
+				return nil, err
+			}
+
+			pd.Params = append(pd.Params, Param{
+				Name:        p.FormName(),
+				Filename:    p.FileName(),
+				ContentType: p.Header.Get("Content-Type"),
+				Value:       string(body),
+			})
+		}
+	case "application/x-www-form-urlencoded":
+		body, err := ioutil.ReadAll(br)
+		if err != nil {
+			return nil, err
+		}
+
+		vs, err := url.ParseQuery(string(body))
+		if err != nil {
+			return nil, err
+		}
+
+		for n, vs := range vs {
+			for _, v := range vs {
+				pd.Params = append(pd.Params, Param{
+					Name:  n,
+					Value: v,
+				})
+			}
+		}
+	default:
+		body, err := ioutil.ReadAll(br)
+		if err != nil {
+			return nil, err
+		}
+
+		pd.Text = string(body)
+	}
+
+	return pd, nil
+}
+
+type byRequestDate []*Entry
+
+// Len returns the length of the slice of entries.
+func (e byRequestDate) Len() int { return len(e) }
+
+// Swap swaps entries by position.
+func (e byRequestDate) Swap(i, j int) { e[i], e[j] = e[j], e[i] }
+
+// Less returns whether the entry at i has a StartedDateTime before the entry at j.
+func (e byRequestDate) Less(i, j int) bool {
+	return e[i].StartedDateTime.Before(e[j].StartedDateTime)
+}

--- a/har/har_handlers.go
+++ b/har/har_handlers.go
@@ -1,0 +1,57 @@
+// Copyright 2015 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package har
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type exportHandler struct {
+	logger *Logger
+}
+
+type resetHandler struct {
+	logger *Logger
+}
+
+// NewExportHandler returns an http.Handler for requesting HAR logs.
+func NewExportHandler(l *Logger) http.Handler {
+	return &exportHandler{
+		logger: l,
+	}
+}
+
+// NewResetHandler returns an http.Handler for clearing in-memory log entries.
+func NewResetHandler(l *Logger) http.Handler {
+	return &resetHandler{
+		logger: l,
+	}
+}
+
+// ServeHTTP writes the log in HAR format to the response body.
+func (h *exportHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	rw.Header().Set("Content-Type", "application/json; charset=utf-8")
+
+	hl := h.logger.Export()
+	json.NewEncoder(rw).Encode(hl)
+}
+
+// ServeHTTP resets the log, which clears its entries.
+func (h *resetHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	h.logger.Reset()
+
+	rw.WriteHeader(http.StatusNoContent)
+}

--- a/har/har_handlers_test.go
+++ b/har/har_handlers_test.go
@@ -1,0 +1,110 @@
+// Copyright 2015 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package har
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/martian"
+	"github.com/google/martian/proxyutil"
+	"github.com/google/martian/session"
+)
+
+func TestExportHandlerServeHTTP(t *testing.T) {
+	logger := NewLogger("martian", "2.0.0")
+
+	req, err := http.NewRequest("GET", "http://example.com", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest(): got %v, want no error", err)
+	}
+
+	ctx, err := session.FromContext(nil)
+	if err != nil {
+		t.Fatalf("session.FromContext(): got %v, want no error", err)
+	}
+	martian.SetContext(req, ctx)
+	defer martian.RemoveContext(req)
+
+	if err := logger.ModifyRequest(req); err != nil {
+		t.Fatalf("ModifyRequest(): got %v, want no error", err)
+	}
+
+	res := proxyutil.NewResponse(200, nil, req)
+	if err := logger.ModifyResponse(res); err != nil {
+		t.Fatalf("ModifyResponse(): got %v, want no error", err)
+	}
+
+	h := NewExportHandler(logger)
+
+	req, err = http.NewRequest("GET", "/", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest(): got %v, want no error", err)
+	}
+
+	rw := httptest.NewRecorder()
+	h.ServeHTTP(rw, req)
+	if got, want := rw.Code, http.StatusOK; got != want {
+		t.Errorf("rw.Code: got %d, want %d", got, want)
+	}
+
+	hl := &HAR{}
+	if err := json.Unmarshal(rw.Body.Bytes(), hl); err != nil {
+		t.Fatalf("json.Unmarshal(): got %v, want no error", err)
+	}
+
+	if got, want := len(hl.Log.Entries), 1; got != want {
+		t.Fatalf("len(hl.Log.Entries): got %v, want %v", got, want)
+	}
+
+	entry := hl.Log.Entries[0]
+	if got, want := entry.Request.URL, "http://example.com"; got != want {
+		t.Errorf("Request.URL: got %q, want %q", got, want)
+	}
+	if got, want := entry.Response.Status, 200; got != want {
+		t.Errorf("Response.Status: got %d, want %d", got, want)
+	}
+
+	rh := NewResetHandler(logger)
+	req, err = http.NewRequest("DELETE", "/", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest(): got %v, want no error", err)
+	}
+
+	rw = httptest.NewRecorder()
+	rh.ServeHTTP(rw, req)
+
+	req, err = http.NewRequest("GET", "/", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest(): got %v, want no error", err)
+	}
+
+	rw = httptest.NewRecorder()
+	h.ServeHTTP(rw, req)
+	if got, want := rw.Code, http.StatusOK; got != want {
+		t.Errorf("rw.Code: got %d, want %d", got, want)
+	}
+
+	hl = &HAR{}
+	if err := json.Unmarshal(rw.Body.Bytes(), hl); err != nil {
+		t.Fatalf("json.Unmarshal(): got %v, want no error", err)
+	}
+
+	if got, want := len(hl.Log.Entries), 0; got != want {
+		t.Errorf("len(Log.Entries): got %v, want %v", got, want)
+	}
+}

--- a/har/har_test.go
+++ b/har/har_test.go
@@ -1,0 +1,564 @@
+// Copyright 2015 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package har
+
+import (
+	"bytes"
+	"mime/multipart"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/martian"
+	"github.com/google/martian/proxyutil"
+	"github.com/google/martian/session"
+)
+
+func TestModifyRequest(t *testing.T) {
+	req, err := http.NewRequest("GET", "http://example.com/path?query=true", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest(): got %v, want no error", err)
+	}
+	req.Header.Add("Request-Header", "first")
+	req.Header.Add("Request-Header", "second")
+
+	cookie := &http.Cookie{
+		Name:  "request",
+		Value: "cookie",
+	}
+	req.AddCookie(cookie)
+
+	ctx, err := session.FromContext(nil)
+	if err != nil {
+		t.Fatalf("session.FromContext(): got %v, want no error", err)
+	}
+	martian.SetContext(req, ctx)
+	defer martian.RemoveContext(req)
+
+	logger := NewLogger("martian", "2.0.0")
+	if err := logger.ModifyRequest(req); err != nil {
+		t.Fatalf("ModifyRequest(): got %v, want no error", err)
+	}
+
+	log := logger.Export().Log
+	if got, want := log.Version, "1.2"; got != want {
+		t.Errorf("log.Version: got %q, want %q", got, want)
+	}
+	if got, want := log.Creator.Name, "martian"; got != want {
+		t.Errorf("log.Creator.Name: got %q, want %q", got, want)
+	}
+	if got, want := log.Creator.Version, "2.0.0"; got != want {
+		t.Errorf("log.Creator.Version: got %q, want %q", got, want)
+	}
+
+	if got, want := len(log.Entries), 1; got != want {
+		t.Fatalf("len(log.Entries): got %d, want %d", got, want)
+	}
+
+	entry := log.Entries[0]
+	if got, want := time.Since(entry.StartedDateTime), time.Second; got > want {
+		t.Errorf("entry.StartedDateTime: got %s, want less than %s", got, want)
+	}
+
+	hreq := entry.Request
+	if got, want := hreq.Method, "GET"; got != want {
+		t.Errorf("hreq.Method: got %q, want %q", got, want)
+	}
+
+	if got, want := hreq.URL, "http://example.com/path?query=true"; got != want {
+		t.Errorf("hreq.URL: got %q, want %q", got, want)
+	}
+
+	if got, want := hreq.HTTPVersion, "HTTP/1.1"; got != want {
+		t.Errorf("hreq.HTTPVersion: got %q, want %q", got, want)
+	}
+
+	if got, want := hreq.BodySize, int64(0); got != want {
+		t.Errorf("hreq.BodySize: got %d, want %d", got, want)
+	}
+
+	if got, want := hreq.HeadersSize, int64(-1); got != want {
+		t.Errorf("hreq.HeadersSize: got %d, want %d", got, want)
+	}
+
+	if got, want := len(hreq.QueryString), 1; got != want {
+		t.Fatalf("len(hreq.QueryString): got %d, want %q", got, want)
+	}
+
+	qs := hreq.QueryString[0]
+	if got, want := qs.Name, "query"; got != want {
+		t.Errorf("qs.Name: got %q, want %q", got, want)
+	}
+	if got, want := qs.Value, "true"; got != want {
+		t.Errorf("qs.Value: got %q, want %q", got, want)
+	}
+
+	if got, want := len(hreq.Headers), 2; got != want {
+		t.Fatalf("len(hreq.Headers): got %d, want %d", got, want)
+	}
+
+	for _, h := range hreq.Headers {
+		var want string
+		switch h.Name {
+		case "Request-Header":
+			want = "first, second"
+		case "Cookie":
+			want = cookie.String()
+		default:
+			t.Errorf("hreq.Headers: got %q, want header to not be present", h.Name)
+			continue
+		}
+
+		if got := h.Value; got != want {
+			t.Errorf("hreq.Headers[%q]: got %q, want %q", h.Name, got, want)
+		}
+	}
+
+	if got, want := len(hreq.Cookies), 1; got != want {
+		t.Fatalf("len(hreq.Cookies): got %d, want %d", got, want)
+	}
+
+	hcookie := hreq.Cookies[0]
+	if got, want := hcookie.Name, "request"; got != want {
+		t.Errorf("hcookie.Name: got %q, want %q", got, want)
+	}
+	if got, want := hcookie.Value, "cookie"; got != want {
+		t.Errorf("hcookie.Value: got %q, want %q", got, want)
+	}
+}
+
+func TestModifyResponse(t *testing.T) {
+	req, err := http.NewRequest("GET", "http://example.com", nil)
+	if err != nil {
+		t.Fatalf("NewRequest(): got %v, want no error", err)
+	}
+
+	ctx, err := session.FromContext(nil)
+	if err != nil {
+		t.Fatalf("session.FromContext(): got %v, want no error", err)
+	}
+	martian.SetContext(req, ctx)
+	defer martian.RemoveContext(req)
+
+	res := proxyutil.NewResponse(301, strings.NewReader("response body"), req)
+	res.Header.Add("Response-Header", "first")
+	res.Header.Add("Response-Header", "second")
+	res.Header.Set("Location", "google.com")
+
+	expires := time.Now()
+	cookie := &http.Cookie{
+		Name:     "response",
+		Value:    "cookie",
+		Path:     "/",
+		Domain:   "example.com",
+		Expires:  expires,
+		Secure:   true,
+		HttpOnly: true,
+	}
+	res.Header.Set("Set-Cookie", cookie.String())
+
+	logger := NewLogger("martian", "2.0.0")
+
+	if err := logger.ModifyRequest(req); err != nil {
+		t.Fatalf("ModifyRequest(): got %v, want no error", err)
+	}
+
+	if err := logger.ModifyResponse(res); err != nil {
+		t.Fatalf("ModifyResponse(): got %v, want no error", err)
+	}
+
+	log := logger.Export().Log
+	if got, want := len(log.Entries), 1; got != want {
+		t.Fatalf("len(log.Entries): got %d, want %d", got, want)
+	}
+
+	hres := log.Entries[0].Response
+	if got, want := hres.Status, 301; got != want {
+		t.Errorf("hres.Status: got %d, want %d", got, want)
+	}
+
+	if got, want := hres.StatusText, "Moved Permanently"; got != want {
+		t.Errorf("hres.StatusText: got %q, want %q", got, want)
+	}
+
+	if got, want := hres.HTTPVersion, "HTTP/1.1"; got != want {
+		t.Errorf("hres.HTTPVersion: got %q, want %q", got, want)
+	}
+
+	if got, want := hres.Content.Text, []byte("response body"); !bytes.Equal(got, want) {
+		t.Errorf("hres.Content.Text: got %q, want %q", got, want)
+	}
+
+	if got, want := len(hres.Headers), 3; got != want {
+		t.Fatalf("len(hreq.Headers): got %d, want %d", got, want)
+	}
+
+	for _, h := range hres.Headers {
+		var want string
+		switch h.Name {
+		case "Response-Header":
+			want = "first, second"
+		case "Location":
+			want = "google.com"
+		case "Set-Cookie":
+			want = cookie.String()
+		default:
+			t.Errorf("hres.Headers: got %q, want header to not be present", h.Name)
+			continue
+		}
+
+		if got := h.Value; got != want {
+			t.Errorf("hres.Headers[%q]: got %q, want %q", h.Name, got, want)
+		}
+	}
+
+	if got, want := len(hres.Cookies), 1; got != want {
+		t.Fatalf("len(hres.Cookies): got %d, want %d", got, want)
+	}
+
+	hcookie := hres.Cookies[0]
+	if got, want := hcookie.Name, "response"; got != want {
+		t.Errorf("hcookie.Name: got %q, want %q", got, want)
+	}
+	if got, want := hcookie.Value, "cookie"; got != want {
+		t.Errorf("hcookie.Value: got %q, want %q", got, want)
+	}
+	if got, want := hcookie.Path, "/"; got != want {
+		t.Errorf("hcookie.Path: got %q, want %q", got, want)
+	}
+	if got, want := hcookie.Domain, "example.com"; got != want {
+		t.Errorf("hcookie.Domain: got %q, want %q", got, want)
+	}
+	if got, want := hcookie.Expires, expires; got.Equal(want) {
+		t.Errorf("hcookie.Expires: got %s, want %s", got, want)
+	}
+	if !hcookie.HTTPOnly {
+		t.Error("hcookie.HTTPOnly: got false, want true")
+	}
+	if !hcookie.Secure {
+		t.Error("hcookie.Secure: got false, want true")
+	}
+}
+
+func TestModifyRequestBodyURLEncoded(t *testing.T) {
+	logger := NewLogger("martian", "2.0.0")
+
+	body := strings.NewReader("first=true&second=false")
+	req, err := http.NewRequest("POST", "http://example.com", body)
+	if err != nil {
+		t.Fatalf("http.NewRequest(): got %v, want no error", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	ctx, err := session.FromContext(nil)
+	if err != nil {
+		t.Fatalf("session.FromContext(): got %v, want no error", err)
+	}
+	martian.SetContext(req, ctx)
+	defer martian.RemoveContext(req)
+
+	if err := logger.ModifyRequest(req); err != nil {
+		t.Fatalf("ModifyRequest(): got %v, want no error", err)
+	}
+
+	log := logger.Export().Log
+	if got, want := len(log.Entries), 1; got != want {
+		t.Errorf("len(log.Entries): got %v, want %v", got, want)
+	}
+
+	pd := log.Entries[0].Request.PostData
+	if got, want := pd.MimeType, "application/x-www-form-urlencoded"; got != want {
+		t.Errorf("PostData.MimeType: got %v, want %v", got, want)
+	}
+
+	if got, want := len(pd.Params), 2; got != want {
+		t.Fatalf("len(PostData.Params): got %d, want %d", got, want)
+	}
+
+	for _, p := range pd.Params {
+		var want string
+		switch p.Name {
+		case "first":
+			want = "true"
+		case "second":
+			want = "false"
+		default:
+			t.Errorf("PostData.Params: got %q, want to not be present", p.Name)
+			continue
+		}
+
+		if got := p.Value; got != want {
+			t.Errorf("PostData.Params[%q]: got %q, want %q", p.Name, got, want)
+		}
+	}
+}
+
+func TestModifyRequestBodyArbitraryContentType(t *testing.T) {
+	logger := NewLogger("martian", "2.0.0")
+
+	body := "arbitrary binary data"
+	req, err := http.NewRequest("POST", "http://www.example.com", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("http.NewRequest(): got %v, want no error", err)
+	}
+
+	ctx, err := session.FromContext(nil)
+	if err != nil {
+		t.Fatalf("session.FromContext(): got %v, want no error", err)
+	}
+	martian.SetContext(req, ctx)
+	defer martian.RemoveContext(req)
+
+	if err := logger.ModifyRequest(req); err != nil {
+		t.Fatalf("ModifyRequest(): got %v, want no error", err)
+	}
+
+	log := logger.Export().Log
+	if got, want := len(log.Entries), 1; got != want {
+		t.Errorf("len(log.Entries): got %d, want %d", got, want)
+	}
+
+	pd := log.Entries[0].Request.PostData
+	if got, want := pd.MimeType, ""; got != want {
+		t.Errorf("PostData.MimeType: got %q, want %q", got, want)
+	}
+	if got, want := len(pd.Params), 0; got != want {
+		t.Errorf("len(PostData.Params): got %d, want %d", got, want)
+	}
+
+	if got, want := pd.Text, body; got != want {
+		t.Errorf("PostData.Text: got %q, want %q", got, want)
+	}
+}
+
+func TestModifyRequestBodyMultipart(t *testing.T) {
+	logger := NewLogger("martian", "2.0.0")
+
+	body := new(bytes.Buffer)
+	mpw := multipart.NewWriter(body)
+	mpw.SetBoundary("boundary")
+
+	if err := mpw.WriteField("key", "value"); err != nil {
+		t.Errorf("mpw.WriteField(): got %v, want no error", err)
+	}
+
+	w, err := mpw.CreateFormFile("file", "test.txt")
+	if _, err = w.Write([]byte("file contents")); err != nil {
+		t.Fatalf("Write(): got %v, want no error", err)
+	}
+	mpw.Close()
+
+	req, err := http.NewRequest("POST", "http://example.com", body)
+	if err != nil {
+		t.Fatalf("http.NewRequest(): got %v, want no error", err)
+	}
+	req.Header.Set("Content-Type", mpw.FormDataContentType())
+
+	ctx, err := session.FromContext(nil)
+	if err != nil {
+		t.Fatalf("session.FromContext(): got %v, want no error", err)
+	}
+	martian.SetContext(req, ctx)
+	defer martian.RemoveContext(req)
+
+	if err := logger.ModifyRequest(req); err != nil {
+		t.Fatalf("ModifyRequest(): got %v, want no error", err)
+	}
+
+	log := logger.Export().Log
+	if got, want := len(log.Entries), 1; got != want {
+		t.Fatalf("len(log.Entries): got %d, want %d", got, want)
+	}
+
+	pd := log.Entries[0].Request.PostData
+	if got, want := pd.MimeType, "multipart/form-data"; got != want {
+		t.Errorf("PostData.MimeType: got %q, want %q", got, want)
+	}
+	if got, want := len(pd.Params), 2; got != want {
+		t.Errorf("PostData.Params: got %d, want %d", got, want)
+	}
+
+	for _, p := range pd.Params {
+		var want Param
+
+		switch p.Name {
+		case "key":
+			want = Param{
+				Filename:    "",
+				ContentType: "",
+				Value:       "value",
+			}
+		case "file":
+			want = Param{
+				Filename:    "test.txt",
+				ContentType: "application/octet-stream",
+				Value:       "file contents",
+			}
+		default:
+			t.Errorf("pd.Params: got %q, want not to be present", p.Name)
+			continue
+		}
+
+		if got, want := p.Filename, want.Filename; got != want {
+			t.Errorf("p.Filename: got %q, want %q", got, want)
+		}
+		if got, want := p.ContentType, want.ContentType; got != want {
+			t.Errorf("p.ContentType: got %q, want %q", got, want)
+		}
+		if got, want := p.Value, want.Value; got != want {
+			t.Errorf("p.Value: got %q, want %q", got, want)
+		}
+	}
+}
+
+func TestHARExportsTime(t *testing.T) {
+	logger := NewLogger("martian", "2.0.0")
+
+	req, err := http.NewRequest("GET", "http://example.com", nil)
+	if err != nil {
+		t.Fatalf("NewRequest(): got %v, want no error", err)
+	}
+
+	ctx, err := session.FromContext(nil)
+	if err != nil {
+		t.Fatalf("session.FromContext(): got %v, want no error", err)
+	}
+	martian.SetContext(req, ctx)
+	defer martian.RemoveContext(req)
+
+	if err := logger.ModifyRequest(req); err != nil {
+		t.Fatalf("ModifyRequest(): got %v, want no error", err)
+	}
+
+	// Simulate fast network round trip.
+	time.Sleep(10 * time.Millisecond)
+
+	res := proxyutil.NewResponse(200, nil, req)
+
+	if err := logger.ModifyResponse(res); err != nil {
+		t.Fatalf("ModifyResponse(): got %v, want no error", err)
+	}
+
+	log := logger.Export().Log
+	if got, want := len(log.Entries), 1; got != want {
+		t.Fatalf("len(log.Entries): got %v, want %v", got, want)
+	}
+
+	entry := log.Entries[0]
+	min, max := int64(10), int64(100)
+	if got := entry.Time; got < min || got > max {
+		t.Errorf("entry.Time: got %dms, want between %dms and %vms", got, min, max)
+	}
+}
+
+func TestReset(t *testing.T) {
+	logger := NewLogger("martian", "2.0.0")
+
+	req, err := http.NewRequest("GET", "http://example.com", nil)
+	if err != nil {
+		t.Fatalf("NewRequest(): got %v, want no error", err)
+	}
+
+	ctx, err := session.FromContext(nil)
+	if err != nil {
+		t.Fatalf("session.FromContext(): got %v, want no error", err)
+	}
+	martian.SetContext(req, ctx)
+	defer martian.RemoveContext(req)
+
+	if err := logger.ModifyRequest(req); err != nil {
+		t.Fatalf("ModifyRequest(): got %v, want no error", err)
+	}
+
+	log := logger.Export().Log
+	if got, want := len(log.Entries), 1; got != want {
+		t.Fatalf("len(log.Entries): got %d, want %d", got, want)
+	}
+
+	logger.Reset()
+
+	log = logger.Export().Log
+	if got, want := len(log.Entries), 0; got != want {
+		t.Errorf("len(log.Entries): got %d, want %d", got, want)
+	}
+}
+
+func TestExportSortsEntries(t *testing.T) {
+	logger := NewLogger("martian", "2.0.0")
+	count := 10
+
+	for i := 0; i < count; i++ {
+		req, err := http.NewRequest("GET", "http://example.com", nil)
+		if err != nil {
+			t.Fatalf("NewRequest(): got %v, want no error", err)
+		}
+
+		ctx, err := session.FromContext(nil)
+		if err != nil {
+			t.Fatalf("session.FromContext(): got %v, want no error", err)
+		}
+		martian.SetContext(req, ctx)
+		defer martian.RemoveContext(req)
+
+		if err := logger.ModifyRequest(req); err != nil {
+			t.Fatalf("ModifyRequest(): got %v, want no error", err)
+		}
+	}
+
+	log := logger.Export().Log
+
+	for i := 0; i < count-1; i++ {
+		first := log.Entries[i]
+		second := log.Entries[i+1]
+
+		if got, want := first.StartedDateTime, second.StartedDateTime; got.After(want) {
+			t.Errorf("entry.StartedDateTime: got %s, want to be before %s", got, want)
+		}
+	}
+}
+
+func TestExportIgnoresOrphanedResponse(t *testing.T) {
+	logger := NewLogger("martian", "2.0.0")
+
+	req, err := http.NewRequest("GET", "http://example.com", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest(): got %v, want no error", err)
+	}
+
+	ctx, err := session.FromContext(nil)
+	if err != nil {
+		t.Fatalf("session.FromContext(): got %v, want no error", err)
+	}
+	martian.SetContext(req, ctx)
+	defer martian.RemoveContext(req)
+
+	if err := logger.ModifyRequest(req); err != nil {
+		t.Fatalf("ModifyRequest(): got %v, want no error", err)
+	}
+
+	// Reset before the response comes back.
+	logger.Reset()
+
+	res := proxyutil.NewResponse(200, nil, req)
+	if err := logger.ModifyResponse(res); err != nil {
+		t.Fatalf("ModifyResponse(): got %v, want no error", err)
+	}
+
+	log := logger.Export().Log
+	if got, want := len(log.Entries), 0; got != want {
+		t.Errorf("len(log.Entries): got %d, want %d", got, want)
+	}
+}

--- a/messageview/messageview.go
+++ b/messageview/messageview.go
@@ -106,7 +106,7 @@ func (mv *MessageView) SnapshotRequest(req *http.Request) error {
 	mv.traileroffset = int64(buf.Len())
 
 	ct := req.Header.Get("Content-Type")
-	if mv.skipBody && !mv.matchContentType(ct) {
+	if mv.skipBody && !mv.matchContentType(ct) || req.Body == nil {
 		mv.message = buf.Bytes()
 		return nil
 	}
@@ -169,7 +169,7 @@ func (mv *MessageView) SnapshotResponse(res *http.Response) error {
 	mv.traileroffset = int64(buf.Len())
 
 	ct := res.Header.Get("Content-Type")
-	if mv.skipBody && !mv.matchContentType(ct) {
+	if mv.skipBody && !mv.matchContentType(ct) || res.Body == nil {
 		mv.message = buf.Bytes()
 		return nil
 	}


### PR DESCRIPTION
Add a HAR logger to Martian. It is mostly to spec (or at least intends to be) except for three specific exceptions:

*  Entries can have a `request` without an accompanying `response`. This allows one to take a snapshot of the current logs even if the response hasn't come back yet (such as if it's taking too long).
*  `entry.time` is the delta between the last request modification and response modification, approximately the round trip time for the client. It does not reflect the sum of `timings.{send,wait,receive}`.
*  `timings` is semantically empty because we reuse http.RoundTripper and don't have access to those numbers, but the `send`, `wait`, and `receive` keys are required to be present so they are.

Fixes #32