### PR TITLE
README: update port example to use -addr flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ flag:
 By default, Martian will be running on port 8080. The port can be specified via
 a flag:
 
-    $GOPATH/bin/proxy -port=9999
+    $GOPATH/bin/proxy -addr=:9999
 
 ### Logging
 For logging of requests and responses a [logging


### PR DESCRIPTION
Hi! I just installed the proxy via

    go get github.com/google/martian/cmd/proxy
    go install github.com/google/martian/cmd/proxy

and I tried to set the port via `proxy -port=9090`, but found:

    bash-3.2$ proxy -port=9090
    flag provided but not defined: -port

whereas using the `-addr` flag works as described in the help:

    bash-3.2$ proxy -addr=:9090
    2015/11/11 11:07:53 martian: proxy started on: [::]:9090

This pr just changes the incorrect line in the readme, assuming that the change was made without updating docs (and not that the docs represent an upcoming API change :P)


