### PR TITLE
clarify install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Go 1.5
 ### Installation
 Martian Proxy can be installed using `go install`
 
+    go get github.com/google/martian/ && \
     go install github.com/google/martian/cmd/proxy
 
 ### Start the Proxy


### PR DESCRIPTION
I had some trouble getting started using `martian`, and then realized I needed to `go get` it first, instead of cloning it via git.