### PR TITLE
cmd/proxy: add support for transparent TLS MITM listener.

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -178,6 +178,8 @@
 //     enable traffic shaping endpoints for simulating latency and constrained
 //     bandwidth conditions (e.g. mobile, exotic network infrastructure, the
 //     90's)
+//   -skip-tls-verify=false
+//     skip TLS server verification; insecure and intended for testing only
 //   -v=0
 //     log level for console logs; defaults to error only.
 package main
@@ -228,6 +230,7 @@ var (
 	allowCORS      = flag.Bool("cors", false, "allow CORS requests to configure the proxy")
 	harLogging     = flag.Bool("har", false, "enable HAR logging API")
 	trafficShaping = flag.Bool("traffic-shaping", false, "enable traffic shaping API")
+	skipTLSVerify  = flag.Bool("skip-tls-verify", false, "skip TLS server verification; insecure")
 )
 
 func main() {
@@ -270,6 +273,7 @@ func main() {
 
 		mc.SetValidity(*validity)
 		mc.SetOrganization(*organization)
+		mc.SkipTLSVerify(*skipTLSVerify)
 
 		p.SetMITM(mc)
 

--- a/mitm/mitm_test.go
+++ b/mitm/mitm_test.go
@@ -43,6 +43,9 @@ func TestMITM(t *testing.T) {
 	if got := conf.NextProtos; !reflect.DeepEqual(got, protos) {
 		t.Errorf("conf.NextProtos: got %v, want %v", got, protos)
 	}
+	if conf.InsecureSkipVerify {
+		t.Error("conf.InsecureSkipVerify: got true, want false")
+	}
 
 	// Simulate a TLS connection without SNI.
 	clientHello := &tls.ClientHelloInfo{
@@ -66,9 +69,14 @@ func TestMITM(t *testing.T) {
 		t.Errorf("x509c.Subject.CommonName: got %q, want %q", got, want)
 	}
 
+	c.SkipTLSVerify(true)
+
 	conf = c.TLSForHost("example.com")
 	if got := conf.NextProtos; !reflect.DeepEqual(got, protos) {
 		t.Errorf("conf.NextProtos: got %v, want %v", got, protos)
+	}
+	if !conf.InsecureSkipVerify {
+		t.Error("conf.InsecureSkipVerify: got false, want true")
 	}
 
 	// Set SNI, takes precendence over host.


### PR DESCRIPTION
@brunoqc We should have support for transparent MITM on TLS in the library, but I don't think it ever got added to the cmd/proxy. Mind giving this branch a try and letting me know if it works for your use case?