### PR TITLE
messageview: fix bug for messages missing Content-Length and Transfer-Encoding

### DIFF
--- a/messageview/messageview.go
+++ b/messageview/messageview.go
@@ -88,7 +88,7 @@ func (mv *MessageView) SnapshotRequest(req *http.Request) error {
 		mv.chunked = req.TransferEncoding[tec-1] == "chunked"
 		fmt.Fprintf(buf, "Transfer-Encoding: %s\r\n", strings.Join(req.TransferEncoding, ", "))
 	}
-	if !mv.chunked {
+	if !mv.chunked && req.ContentLength >= 0 {
 		fmt.Fprintf(buf, "Content-Length: %d\r\n", req.ContentLength)
 	}
 
@@ -152,7 +152,7 @@ func (mv *MessageView) SnapshotResponse(res *http.Response) error {
 		mv.chunked = res.TransferEncoding[tec-1] == "chunked"
 		fmt.Fprintf(buf, "Transfer-Encoding: %s\r\n", strings.Join(res.TransferEncoding, ", "))
 	}
-	if !mv.chunked {
+	if !mv.chunked && res.ContentLength >= 0 {
 		fmt.Fprintf(buf, "Content-Length: %d\r\n", res.ContentLength)
 	}
 

--- a/messageview/messageview_test.go
+++ b/messageview/messageview_test.go
@@ -86,8 +86,11 @@ func TestRequestView(t *testing.T) {
 	if err != nil {
 		t.Fatalf("http.NewRequest(): got %v, want no error", err)
 	}
-	req.ContentLength = 12
 	req.Header.Set("Request-Header", "true")
+
+	// Force Content Length to be unset to simulate lack of Content-Length and
+	// Transfer-Encoding which is valid.
+	req.ContentLength = -1
 
 	mv := New()
 	if err := mv.SnapshotRequest(req); err != nil {
@@ -101,7 +104,6 @@ func TestRequestView(t *testing.T) {
 
 	hdrwant := "GET http://example.com/path?k=v HTTP/1.1\r\n" +
 		"Host: example.com\r\n" +
-		"Content-Length: 12\r\n" +
 		"Request-Header: true\r\n\r\n"
 
 	if !bytes.Equal(got, []byte(hdrwant)) {


### PR DESCRIPTION
We were incorrectly printing the Content-Length if Transfer-Encoding is not chunked without checking that there was, in fact, a valid Content-Length. Seeing tests fail trying to parse an invalid, negative, Content-Length header.