### PR TITLE
Add TLSHandshakeErrorHandler callback function to mitm config

### DIFF
--- a/mitm/mitm.go
+++ b/mitm/mitm.go
@@ -27,7 +27,8 @@ import (
 	"crypto/x509/pkix"
 	"errors"
 	"math/big"
-	"net"
+	"net"	
+	"net/http"
 	"sync"
 	"time"
 
@@ -51,6 +52,7 @@ type Config struct {
 	getCertificate func(*tls.ClientHelloInfo) (*tls.Certificate, error)
 	roots          *x509.CertPool
 	skipVerify     bool
+	TLSHandshakeErrorHandler func(*http.Request, error)
 
 	certmu sync.RWMutex
 	certs  map[string]*tls.Certificate

--- a/proxy.go
+++ b/proxy.go
@@ -333,12 +333,8 @@ func (p *Proxy) handle(ctx *Context, conn net.Conn, brw *bufio.ReadWriter) error
 				// http.ReadRequest.
 				tlsconn := tls.Server(&peekedConn{conn, io.MultiReader(bytes.NewReader(b), bytes.NewReader(buf), conn)}, p.mitm.TLSForHost(req.Host))
 
-				log.Errorf("Calling handshake")
-
 				if err := tlsconn.Handshake(); err != nil && p.mitm.TLSHandshakeErrorHandler != nil {
-					log.Errorf("Handshake error: %v", err)
 					p.mitm.TLSHandshakeErrorHandler(req, err)
-					log.Errorf("Handshake error: %v", err)
 					return err
 				}
 

--- a/proxy.go
+++ b/proxy.go
@@ -333,6 +333,15 @@ func (p *Proxy) handle(ctx *Context, conn net.Conn, brw *bufio.ReadWriter) error
 				// http.ReadRequest.
 				tlsconn := tls.Server(&peekedConn{conn, io.MultiReader(bytes.NewReader(b), bytes.NewReader(buf), conn)}, p.mitm.TLSForHost(req.Host))
 
+				log.Errorf("Calling handshake")
+
+				if err := tlsconn.Handshake(); err != nil && p.mitm.TLSHandshakeErrorHandler != nil {
+					log.Errorf("Handshake error: %v", err)
+					p.mitm.TLSHandshakeErrorHandler(req, err)
+					log.Errorf("Handshake error: %v", err)
+					return err
+				}
+
 				brw.Writer.Reset(tlsconn)
 				brw.Reader.Reset(tlsconn)
 

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -554,13 +554,11 @@ func TestIntegrationTLSHandshakeErrorCallback(t *testing.T) {
 		t.Fatalf("http.ReadResponse(): got %v, want no error", err)
 	}
 
-	roots := x509.NewCertPool()
-	roots.AddCert(ca)
-
 	tlsconn := tls.Client(conn, &tls.Config{
 		ServerName: "example.com",
-		// client has no cert so it will get "x509: certificate signed by unknown authority" from the 
+		// Client has no cert so it will get "x509: certificate signed by unknown authority" from the 
 		// handshake and send "remote error: bad certificate" to the server.
+		RootCAs: x509.NewCertPool(),
 	})
 	defer tlsconn.Close()
 


### PR DESCRIPTION
Sometimes it can be beneficial to do something in the case of an unhappy client being mitm attacked. This can be caused by the client not having the certificate installed. Surfacing this information can be used to alert a user of what is going wrong or update a web interface.