### PR TITLE
display response latency in olympus mons (when martian sends timestamps)

### DIFF
--- a/web/elements/om-message-list/om-message-list.html
+++ b/web/elements/om-message-list/om-message-list.html
@@ -34,7 +34,6 @@ request and response modifiers.
       }
 
       #message-item-url:after {
-        background: linear-gradient(to left, rgba(255, 255, 255, 1) 0%, rgba(0, 0, 0, 0) 15%);
         content: "";
         display: block;
         height: 60%;
@@ -45,6 +44,11 @@ request and response modifiers.
 
       .message-item-primary {
         display: flex;
+      }
+
+      .response-latency {
+        font-size: 10px;
+        margin-left: 16px;
       }
 
       .response-status {
@@ -85,6 +89,7 @@ request and response modifiers.
                     class="request-query"
                     hidden$="[[!message.request.query]]">?[[message.request.query]]</span>
                 </div>
+                <div class="response-latency">[[message.response.latency]]</div>
                 <div class="response-status">[[message.response.status]]</div>
               </div>
               <div class="message-item-secondary" secondary>

--- a/web/elements/om-message/om-message.html
+++ b/web/elements/om-message/om-message.html
@@ -51,6 +51,9 @@ request and response modifiers.
     .response-header-value {
       word-wrap: break-word;
     }
+    .response-latency {
+      font-size: 10px;
+    }
 
     @media (max-width: 600px) {
       #message {
@@ -114,6 +117,7 @@ request and response modifiers.
               <span class="response-proto" id="response-proto">[[message.response.proto]]</span>
               <span class="response-status" id="response-status">[[message.response.status]]</span>
               <span class="response-reason" id="response-reason">[[message.response.reason]]</span>
+              <span class="response-latency" id="response-latency">[[message.response.latency]]</span>
             </div>
             <div class="response-headers">
               <dl>

--- a/web/elements/om-messages-stream/om-messages-stream.html
+++ b/web/elements/om-messages-stream/om-messages-stream.html
@@ -59,6 +59,7 @@ request and response modifiers.
         };
       },
       _handleFrame: function(e) {
+        var _this = this;
         var frame = e.detail;
 
         var index = this._indexes[frame.id];
@@ -81,6 +82,18 @@ request and response modifiers.
 
             if (header.pseudo) {
               message[frame.scope][frame.name.slice(1)] = frame.value;
+              if (true
+                  && frame.name.slice(1) == "timestamp"
+                  && message.request != undefined && message.request.timestamp != undefined
+                  && message.response != undefined && message.response.timestamp != undefined) {
+                var rawLatency = parseInt(message.response.timestamp) - parseInt(message.request.timestamp);
+                if (rawLatency < 1000) {
+                  message.response.latency = rawLatency + "ms";
+                } else {
+                  rawLatency = Math.round(rawLatency / 10) / 100;
+                  message.response.latency = rawLatency + "s";
+                }
+              }
             }
 
             break;
@@ -89,8 +102,17 @@ request and response modifiers.
 
             break;
         }
-        this.debounce('messages.' + index, () => {
-          this.notifyPath('messages.' + index, message);
+        this.debounce('messages.' + index, () => { 
+          var msgcopy = JSON.parse(JSON.stringify(message));
+          _this.messages.splice(index, 1);
+          _this.messages.splice(index, 0, msgcopy);
+          _this.notifySplices('messages', [{
+            index: index,
+            removed: [message],
+            addedCount:1,
+            object:_this.messages,
+            type:"splice"
+          }]);
         }, 100);
       },
     });

--- a/web/test/elements/om-message-list_test.html
+++ b/web/test/elements/om-message-list_test.html
@@ -62,7 +62,8 @@ request and response modifiers.
             "path": "/index.html",
             "query": "foo=bar",
             "proto": "HTTP/1.1",
-            "remote": "[::1]:60221"
+            "remote": "[::1]:60221",
+            "timestamp": "1471064945800"
           },
           "response": {
             "headers": [
@@ -75,7 +76,9 @@ request and response modifiers.
             },
             "status": "200",
             "proto": "HTTP/1.1",
-            "reason": "200 OK"
+            "reason": "200 OK",
+            "timestamp": "1471064946000",
+            "latency": "200ms"
           }
         };
         var getVisibleListItems = function() {
@@ -86,7 +89,6 @@ request and response modifiers.
           let element = fixture('basic');
           assert.equal(element.is, 'om-message-list');
         });
-
         test('populate list of messages', function(done) {
           let element = fixture('basic');
           var message2 = JSON.parse(JSON.stringify(message1));
@@ -101,7 +103,24 @@ request and response modifiers.
             assert.equal(3, getVisibleListItems().length);
             done();
           });
+        });
+        test('display timestamp in messages', function(done) {
+          let element = fixture('basic');
+          var message2 = JSON.parse(JSON.stringify(message1));
+          message2.id = "0ddba115";
+          message2.request.timestamp = "147106494500";
+          message2.response.latency = "500ms";
 
+          element.messages = [message1, message2];
+          element.querySelector('iron-list').notifyResize();
+
+          flush(function() {
+            var items = getVisibleListItems();
+            assert.equal(2, items.length);
+            assert.equal("200ms", items[0].querySelector(".response-latency").innerText);
+            assert.equal("500ms", items[1].querySelector(".response-latency").innerText);
+            done();
+          });
         });
         test('search a list of messages', function(done) {
           let element = fixture('basic');

--- a/web/test/elements/om-message_test.html
+++ b/web/test/elements/om-message_test.html
@@ -191,6 +191,18 @@ request and response modifiers.
           element.message = {"response": {"status": "404"}};
           assert.equal("404", status.innerText);
         });
+        test('response latency displayed', function() {
+          let element = fixture('basic');
+          var status = element.$["response-latency"];
+
+          assert.equal("", status.innerText);
+
+          element.message = {"response": {"latency": "20ms"}};
+          assert.equal("20ms", status.innerText);
+
+          element.message = {"response": {"latency": "40ms"}};
+          assert.equal("40ms", status.innerText);
+        });
         test('response reason displayed', function() {
           let element = fixture('basic');
           var reason = element.$["response-reason"];


### PR DESCRIPTION
added timestamp display when its being logged by the martian, and fixed a bug that sometimes caused response code and latency not to render (which was required some real fighting of polymer, which makes false assumptions about whether things have changed)