### PR TITLE
fix URLs of js imports 

### DIFF
--- a/web/elements/om-message-list/om-message-list.html
+++ b/web/elements/om-message-list/om-message-list.html
@@ -158,14 +158,13 @@ request and response modifiers.
       },
       _parseFile: function(file) {
         var reader = new FileReader();
-        var worker = new Worker('/elements/om-message-list/parse-log.js');
+        var worker = new Worker('elements/om-message-list/parse-log.js');
 
         worker.addEventListener('message', function(e) {
           this.fire('message-frame', e.data);
         }.bind(this));
 
         reader.onload = function(e) {
-          console.log('read file, posting to web worker');
           worker.postMessage(e.target.result, [e.target.result]);
         };
 
@@ -176,8 +175,6 @@ request and response modifiers.
         reader.readAsArrayBuffer(file);
       },
       _loadLogsFromUrl: function() {
-        console.log("Checking whether ?martian= param exists"
-            + " and is the url of a .marbl file");
         if (this.martian.search("wss?://") == 0) {
           console.log("Provided martian looks like a websocket; not"
               + " trying to load a flat .marbl file from it");
@@ -187,28 +184,13 @@ request and response modifiers.
           console.log("Not trying to load .marbl from empty url");
           return;
         }
+        console.log("Looks like the url of a .marbl file (" + this.martian + ")");
         var oReq = new XMLHttpRequest();
         oReq.open("GET", this.martian);
         oReq.responseType = "blob";
         var oml = this;
         oReq.onload = function(oEvent) {
-          var reader = new FileReader();
-          var worker = new Worker('/elements/om-message-list/parse-log.js');
-
-          worker.addEventListener('message', function(e) {
-            oml.fire('message-frame', e.data);
-          }.bind(this));
-
-          reader.onload = function(e) {
-            console.log('read file, posting to web worker');
-            worker.postMessage(e.target.result, [e.target.result]);
-          };
-
-          reader.onerror = function(e) {
-            console.log('error reading file', e);
-          };
-
-          reader.readAsArrayBuffer(oReq.response);
+          oml._parseFile(oReq.response);
         };
         oReq.send(null);
       },

--- a/web/elements/om-message-list/parse-log.js
+++ b/web/elements/om-message-list/parse-log.js
@@ -16,7 +16,7 @@
 // Package martian provides an HTTP/1.1 proxy with an API for configurable
 // request and response modifiers.
 
-importScripts('/scripts/frame-reader.js');
+importScripts('../../scripts/frame-reader.js');
 
 self.addEventListener('message', function(e) {
   var reader = new FrameReader();

--- a/web/elements/om-message-websocket/om-message-websocket.html
+++ b/web/elements/om-message-websocket/om-message-websocket.html
@@ -33,9 +33,6 @@ request and response modifiers.
         this._reader = new FrameReader();
       },
       resetSocket: function() {
-        console.log("Checking whether ?martian= param exists"
-            + " and is the url of a running Martian's"
-            + " websocket");
         if (!this.martian) {
           console.log("No web socket provided; not attempting to connect");
           return;
@@ -44,6 +41,7 @@ request and response modifiers.
           console.log("Martian url is not a websocket; not connecting");
           return;
         }
+        console.log("Martian url looks like a websocket; connecting");
         this._socket = new WebSocket(this.martian);
         this._socket.binaryType = 'arraybuffer';
         var _this = this;


### PR DESCRIPTION
When you import via Worker(), the url of the .js needs to be relative to the top level HTML file being loaded.
When you import via importScripts or <script src="">, the url needs to be relative to the enclosing file.

Also cleaned up some duplication and debug logging