### PR TITLE
Get state of martian on mobile & support restarting martian.

### DIFF
--- a/mobileproxy/mobileproxy.go
+++ b/mobileproxy/mobileproxy.go
@@ -190,6 +190,7 @@ func StartWithCertificate(trafficPort int, apiPort int, cert, key string) (*Mart
 	}, nil
 }
 
+// IsStarted returns true if the proxy has finished starting up.
 func IsStarted() bool {
 	return started
 }

--- a/mobileproxy/mobileproxy.go
+++ b/mobileproxy/mobileproxy.go
@@ -55,7 +55,7 @@ import (
 	_ "github.com/google/martian/status"
 )
 
-var started bool = false
+var started = false
 
 // Martian is a wrapper for the initialized Martian proxy
 type Martian struct {

--- a/proxy.go
+++ b/proxy.go
@@ -119,7 +119,6 @@ func (p *Proxy) Close() {
 	log.Infof("martian: closing down proxy")
 
 	atomic.StoreInt32(&p.closing, 1)
-	p.conns.Wait()
 }
 
 // Closing returns whether the proxy is in the closing state.


### PR DESCRIPTION
Had to stop using the default serve mux to support at least unit testing stopping and starting of martian on mobile.  This is probably useful for real shutdown/restarts as well.

This also no longer waits for open connections to close when calling Close() on the proxy. Previously, this would wait for several minutes every time due to persistent connections.