### PR TITLE
Building query_string filter

### DIFF
--- a/querystring/query_string_filter.go
+++ b/querystring/query_string_filter.go
@@ -16,7 +16,6 @@ package querystring
 
 import (
 	"encoding/json"
-	"net/http"
 
 	"github.com/google/martian"
 	"github.com/google/martian/filter"
@@ -45,7 +44,7 @@ type filterJSON struct {
 // NewFilter builds a querystring.Filter that filters on name and optionally
 // value.
 func NewFilter(name, value string) *Filter {
-	m := NewMatcher(http.CanonicalHeaderKey(name), value)
+	m := NewMatcher(name, value)
 	f := filter.New()
 	f.SetRequestCondition(m)
 	f.SetResponseCondition(m)
@@ -77,14 +76,16 @@ func filterFromJSON(b []byte) (*parse.Result, error) {
 	f.RequestWhenTrue(r.RequestModifier())
 	f.ResponseWhenTrue(r.ResponseModifier())
 
-	em, err := parse.FromJSON(msg.ElseModifier)
-	if err != nil {
-		return nil, err
-	}
+	if len(msg.ElseModifier) > 0 {
+		em, err := parse.FromJSON(msg.ElseModifier)
+		if err != nil {
+			return nil, err
+		}
 
-	if em != nil {
-		f.RequestWhenFalse(em.RequestModifier())
-		f.ResponseWhenFalse(em.ResponseModifier())
+		if em != nil {
+			f.RequestWhenFalse(em.RequestModifier())
+			f.ResponseWhenFalse(em.ResponseModifier())
+		}
 	}
 
 	return parse.NewResult(f, msg.Scope)

--- a/querystring/query_string_filter.go
+++ b/querystring/query_string_filter.go
@@ -19,8 +19,8 @@ import (
 	"net/http"
 
 	"github.com/google/martian"
+	"github.com/google/martian/filter"
 	"github.com/google/martian/parse"
-	"github.com/google/martian/verify"
 )
 
 var noop = martian.Noop("querystring.Filter")
@@ -31,46 +31,25 @@ func init() {
 
 // Filter runs modifiers iff the request query parameter for name matches value.
 type Filter struct {
-	name   string
-	value  string
-	reqmod martian.RequestModifier
-	resmod martian.ResponseModifier
+	*filter.Filter
 }
 
 type filterJSON struct {
-	Name     string               `json:"name"`
-	Value    string               `json:"value"`
-	Modifier json.RawMessage      `json:"modifier"`
-	Scope    []parse.ModifierType `json:"scope"`
+	Name         string               `json:"name"`
+	Value        string               `json:"value"`
+	Modifier     json.RawMessage      `json:"modifier"`
+	ElseModifier json.RawMessage      `json:"else"`
+	Scope        []parse.ModifierType `json:"scope"`
 }
 
 // NewFilter builds a querystring.Filter that filters on name and optionally
 // value.
 func NewFilter(name, value string) *Filter {
-	return &Filter{
-		name:   name,
-		value:  value,
-		reqmod: noop,
-		resmod: noop,
-	}
-}
-
-// SetRequestModifier sets the request modifier for filter.
-func (f *Filter) SetRequestModifier(reqmod martian.RequestModifier) {
-	if reqmod == nil {
-		reqmod = noop
-	}
-
-	f.reqmod = reqmod
-}
-
-// SetResponseModifier sets the response modifier for filter.
-func (f *Filter) SetResponseModifier(resmod martian.ResponseModifier) {
-	if resmod == nil {
-		resmod = noop
-	}
-
-	f.resmod = resmod
+	m := NewMatcher(http.CanonicalHeaderKey(name), value)
+	f := filter.New()
+	f.SetRequestCondition(m)
+	f.SetResponseCondition(m)
+	return &Filter{f}
 }
 
 // filterFromJSON takes a JSON message and returns a querystring.Filter.
@@ -95,82 +74,18 @@ func filterFromJSON(b []byte) (*parse.Result, error) {
 		return nil, err
 	}
 
-	f.SetRequestModifier(r.RequestModifier())
-	f.SetResponseModifier(r.ResponseModifier())
+	f.RequestWhenTrue(r.RequestModifier())
+	f.ResponseWhenTrue(r.ResponseModifier())
+
+	em, err := parse.FromJSON(msg.ElseModifier)
+	if err != nil {
+		return nil, err
+	}
+
+	if em != nil {
+		f.RequestWhenFalse(em.RequestModifier())
+		f.ResponseWhenFalse(em.ResponseModifier())
+	}
 
 	return parse.NewResult(f, msg.Scope)
-}
-
-// ModifyRequest applies the request modifier if the filter name and values
-// match the request query parameters. In the case of an empty value, the modifier is
-// applied whenever any parameter matches name, regardless of its value.
-func (f *Filter) ModifyRequest(req *http.Request) error {
-	if f.matches(req) && f.reqmod != nil {
-		return f.reqmod.ModifyRequest(req)
-	}
-
-	return nil
-}
-
-// ModifyResponse applies the response modifier if the filter name and values
-// match the request query parameters. In the case of an empty value, the modifier is
-// applied whenever any parameter matches name, regardless of its value.
-func (f *Filter) ModifyResponse(res *http.Response) error {
-	if f.matches(res.Request) && f.resmod != nil {
-		return f.resmod.ModifyResponse(res)
-	}
-
-	return nil
-}
-
-func (f *Filter) matches(req *http.Request) bool {
-	for n, vs := range req.URL.Query() {
-		if f.name == n {
-			if f.value == "" {
-				return true
-			}
-
-			for _, v := range vs {
-				if f.value == v {
-					return true
-				}
-			}
-		}
-	}
-
-	return false
-}
-
-// VerifyRequests returns an error containing all the verification errors
-// returned by request verifiers.
-func (f *Filter) VerifyRequests() error {
-	if reqv, ok := f.reqmod.(verify.RequestVerifier); ok {
-		return reqv.VerifyRequests()
-	}
-
-	return nil
-}
-
-// VerifyResponses returns an error containing all the verification errors
-// returned by response verifiers.
-func (f *Filter) VerifyResponses() error {
-	if resv, ok := f.resmod.(verify.ResponseVerifier); ok {
-		return resv.VerifyResponses()
-	}
-
-	return nil
-}
-
-// ResetRequestVerifications resets the state of the contained request verifiers.
-func (f *Filter) ResetRequestVerifications() {
-	if reqv, ok := f.reqmod.(verify.RequestVerifier); ok {
-		reqv.ResetRequestVerifications()
-	}
-}
-
-// ResetResponseVerifications resets the state of the contained response verifiers.
-func (f *Filter) ResetResponseVerifications() {
-	if resv, ok := f.resmod.(verify.ResponseVerifier); ok {
-		resv.ResetResponseVerifications()
-	}
 }

--- a/querystring/query_string_filter_test.go
+++ b/querystring/query_string_filter_test.go
@@ -297,7 +297,9 @@ func TestVerifyRequests(t *testing.T) {
 
 	f.SetRequestModifier(tv)
 
-	if got, want := f.VerifyRequests(), tv.RequestError; got != want {
+	want := verify.NewMultiError()
+	want.Add(tv.RequestError)
+	if got := f.VerifyRequests(); got.Error() != want.Error() {
 		t.Fatalf("VerifyRequests(): got %v, want %v", got, want)
 	}
 
@@ -321,7 +323,9 @@ func TestVerifyResponses(t *testing.T) {
 
 	f.SetResponseModifier(tv)
 
-	if got, want := f.VerifyResponses(), tv.ResponseError; got != want {
+	want := verify.NewMultiError()
+	want.Add(tv.ResponseError)
+	if got := f.VerifyResponses(); got.Error() != want.Error() {
 		t.Fatalf("VerifyResponses(): got %v, want %v", got, want)
 	}
 

--- a/querystring/query_string_matcher.go
+++ b/querystring/query_string_matcher.go
@@ -1,0 +1,34 @@
+package querystring
+
+import "net/http"
+
+type Matcher struct {
+	name, value string
+}
+
+// NewMatcher builds a new querystring matcher
+func NewMatcher(name, value string) *Matcher {
+	return &Matcher{name: name, value: value}
+}
+
+func (m *Matcher) MatchRequest(req *http.Request) bool {
+	for n, vs := range req.URL.Query() {
+		if m.name == n {
+			if m.value == "" {
+				return true
+			}
+
+			for _, v := range vs {
+				if m.value == v {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}
+
+func (m *Matcher) MatchResponse(res *http.Response) bool {
+	return m.MatchRequest(res.Request)
+}


### PR DESCRIPTION
Previously the query string filter had its own matcher implementation. New merging with the newly created matcher in PR #137.