### PR TITLE
Fixing header filter when no else modifiers present in the JSON request

### DIFF
--- a/header/header_filter.go
+++ b/header/header_filter.go
@@ -77,14 +77,16 @@ func filterFromJSON(b []byte) (*parse.Result, error) {
 	filter.RequestWhenTrue(m.RequestModifier())
 	filter.ResponseWhenTrue(m.ResponseModifier())
 
-	em, err := parse.FromJSON(msg.ElseModifier)
-	if err != nil {
-		return nil, err
-	}
+	if len(msg.ElseModifier) > 0 {
+		em, err := parse.FromJSON(msg.ElseModifier)
+		if err != nil {
+			return nil, err
+		}
 
-	if em != nil {
-		filter.RequestWhenFalse(em.RequestModifier())
-		filter.ResponseWhenFalse(em.ResponseModifier())
+		if em != nil {
+			filter.RequestWhenFalse(em.RequestModifier())
+			filter.ResponseWhenFalse(em.ResponseModifier())
+		}
 	}
 
 	return parse.NewResult(filter, msg.Scope)

--- a/header/header_filter_test.go
+++ b/header/header_filter_test.go
@@ -113,6 +113,27 @@ func TestFilterFromJSON(t *testing.T) {
 	}
 }
 
+func TestFilterFromJSONWithoutElse(t *testing.T) {
+	msg := []byte(`{
+		"header.Filter": {
+			"scope": ["request", "response"],
+			"name": "Martian-Passthrough",
+			"value": "true",
+			"modifier": {
+				"header.Modifier" : {
+					"scope": ["request", "response"],
+					"name": "Martian-Testing",
+					"value": "true"
+				}
+			}
+		}
+	}`)
+	_, err := parse.FromJSON(msg)
+	if err != nil {
+		t.Fatalf("parse.FromJSON(): got %v, want no error", err)
+	}
+}
+
 func TestRequestWhenTrueCondition(t *testing.T) {
 	hm := NewMatcher("Martian-Testing", "true")
 


### PR DESCRIPTION
Previously martian will crash when the header filter does not have "else" field in it:

For example: 

>  header_filter_test.go:133: parse.FromJSON(): got unexpected end of JSON input, want no error


On: 
```
{                                                                                                                                                                                         
        "header.Filter": {                                                                                                                                                                                   
            "scope": ["request", "response"],                                                                                                                                                                
            "name": "Martian-Passthrough",                                                                                                                                                                   
            "value": "true",                                                                                                                                                                                 
            "modifier": {                                                                                                                                                                                    
                "header.Modifier" : {                                                                                                                                                                        
                    "scope": ["request", "response"],                                                                                                                                                        
                    "name": "Martian-Testing",                                                                                                                                                               
                    "value": "true"                                                                                                                                                                          
                }                                                                                                                                                                                            
            }                                                                                                                                                                                                
        }                                                                                                                                                                                                    
    }
```

This PR fixes it, by adding a checking condition on whether the else part is empty.

Tested: added a unit test
