### PR TITLE
There are no flags in the mobile interface.

### DIFF
--- a/mobile/init.go
+++ b/mobile/init.go
@@ -23,10 +23,6 @@ import (
 	mlog "github.com/google/martian/log"
 )
 
-var (
-	level = flag.Int("v", 0, "log level")
-)
-
 // Init runs common initialization code for a martian proxy.
 func Init() {
 	flag.Parse()

--- a/mobile/init.go
+++ b/mobile/init.go
@@ -17,11 +17,7 @@
 // be cross compiled with gomobile for use on Android and iOS.
 package mobile
 
-import (
-	"flag"
-)
-
 // Init runs common initialization code for a martian proxy.
 func Init() {
-	flag.Parse()
+	// Add custom code for your environment here.
 }

--- a/mobile/init.go
+++ b/mobile/init.go
@@ -19,12 +19,9 @@ package mobile
 
 import (
 	"flag"
-
-	mlog "github.com/google/martian/log"
 )
 
 // Init runs common initialization code for a martian proxy.
 func Init() {
 	flag.Parse()
-	mlog.SetLevel(*level)
 }


### PR DESCRIPTION
This was accidentally moved here, it should *only* live in the non-mobile init.go.