### PR TITLE
do not log requests that match patterns in mux

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -240,6 +240,7 @@ var (
 	validity       = flag.Duration("validity", time.Hour, "window of time that MITM certificates are valid")
 	allowCORS      = flag.Bool("cors", false, "allow CORS requests to configure the proxy")
 	harLogging     = flag.Bool("har", false, "enable HAR logging API")
+	marblLogging   = flag.Bool("marbl", false, "enable MARBL logging API")
 	trafficShaping = flag.Bool("traffic-shaping", false, "enable traffic shaping API")
 	skipTLSVerify  = flag.Bool("skip-tls-verify", false, "skip TLS server verification; insecure")
 )
@@ -326,8 +327,14 @@ func main() {
 
 	if *harLogging {
 		hl := har.NewLogger()
-		stack.AddRequestModifier(hl)
-		stack.AddResponseModifier(hl)
+		muxf := servemux.NewFilter(nil)
+		// Only append to HAR logs when the requests are not API requests,
+		// that is, they are not matched in http.DefaultServeMux
+		muxf.RequestWhenFalse(hl)
+		muxf.ResponseWhenFalse(hl)
+
+		stack.AddRequestModifier(muxf)
+		stack.AddResponseModifier(muxf)
 
 		configure("/logs", har.NewExportHandler(hl))
 		configure("/logs/reset", har.NewResetHandler(hl))
@@ -339,13 +346,18 @@ func main() {
 	stack.AddRequestModifier(logger)
 	stack.AddResponseModifier(logger)
 
-	lsh := marbl.NewHandler()
-	// retrieve binary marbl logs
-	http.Handle("/binlogs", lsh)
+	if *marblLogging {
+		lsh := marbl.NewHandler()
+		lsm := marbl.NewModifier(lsh)
+		muxf := servemux.NewFilter(nil)
+		muxf.RequestWhenFalse(lsm)
+		muxf.ResponseWhenFalse(lsm)
+		stack.AddRequestModifier(muxf)
+		stack.AddResponseModifier(muxf)
 
-	lsm := marbl.NewModifier(lsh)
-	stack.AddRequestModifier(lsm)
-	stack.AddResponseModifier(lsm)
+		// retrieve binary marbl logs
+		http.Handle("/binlogs", lsh)
+	}
 
 	// Configure modifiers.
 	configure("/configure", m)

--- a/mobile/proxy.go
+++ b/mobile/proxy.go
@@ -140,13 +140,19 @@ func (m *Martian) Start() {
 	if m.HarLogging {
 		// add HAR logger for unmodified logs.
 		uhl := har.NewLogger()
-		fg.AddRequestModifier(uhl)
-		fg.AddResponseModifier(uhl)
+		uhmuxf := servemux.NewFilter(m.mux)
+		uhmuxf.RequestWhenFalse(uhl)
+		uhmuxf.ResponseWhenFalse(uhl)
+		fg.AddRequestModifier(uhmuxf)
+		fg.AddResponseModifier(uhmuxf)
 
 		// add HAR logger
 		hl := har.NewLogger()
-		stack.AddRequestModifier(hl)
-		stack.AddResponseModifier(hl)
+		hmuxf := servemux.NewFilter(m.mux)
+		hmuxf.RequestWhenFalse(hl)
+		hmuxf.ResponseWhenFalse(hl)
+		stack.AddRequestModifier(hmuxf)
+		stack.AddResponseModifier(hmuxf)
 
 		// Retrieve Unmodified HAR logs
 		m.handle("/logs/original", har.NewExportHandler(uhl))
@@ -162,8 +168,11 @@ func (m *Martian) Start() {
 	m.handle("/binlogs", lsh)
 
 	lsm := marbl.NewModifier(lsh)
-	stack.AddRequestModifier(lsm)
-	stack.AddResponseModifier(lsm)
+	muxf := servemux.NewFilter(m.mux)
+	muxf.RequestWhenFalse(lsm)
+	muxf.ResponseWhenFalse(lsm)
+	stack.AddRequestModifier(muxf)
+	stack.AddResponseModifier(muxf)
 
 	mod := martianhttp.NewModifier()
 	fg.AddRequestModifier(mod)

--- a/mobileproxy/mobileproxy.go
+++ b/mobileproxy/mobileproxy.go
@@ -152,13 +152,19 @@ func StartWithCertificateCORS(trafficPort int, apiPort int, cert, key string, al
 
 	// add HAR logger for unmodified logs.
 	uhl := har.NewLogger()
-	fg.AddRequestModifier(uhl)
-	fg.AddResponseModifier(uhl)
+	uhmuxf := servemux.NewFilter(mux)
+	uhmuxf.RequestWhenFalse(uhl)
+	uhmuxf.ResponseWhenFalse(uhl)
+	fg.AddRequestModifier(uhmuxf)
+	fg.AddResponseModifier(uhmuxf)
 
 	// add HAR logger
 	hl := har.NewLogger()
-	stack.AddRequestModifier(hl)
-	stack.AddResponseModifier(hl)
+	hmuxf := servemux.NewFilter(mux)
+	hmuxf.RequestWhenFalse(hl)
+	hmuxf.ResponseWhenFalse(hl)
+	stack.AddRequestModifier(hmuxf)
+	stack.AddResponseModifier(hmuxf)
 
 	m := martianhttp.NewModifier()
 	fg.AddRequestModifier(m)


### PR DESCRIPTION
Requests that match patterns in mux are requests to the proxy API, and they should not be logged