### PR TITLE
Make -skip-tls-verify apply to proxy outbound connection

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -254,6 +254,12 @@ func main() {
 	defer p.Close()
 
 	tr := &http.Transport{
+		Dial: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).Dial,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: time.Second,
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: *skipTLSVerify,
 		},

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -255,9 +255,12 @@ func main() {
 
 	mux := http.NewServeMux()
 
-	if *skipTLSVerify {
-		p.SetSkipTLSVerify(true)
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: *skipTLSVerify,
+		},
 	}
+	p.SetRoundTripper(tr)
 
 	var x509c *x509.Certificate
 	var priv interface{}

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -255,6 +255,10 @@ func main() {
 
 	mux := http.NewServeMux()
 
+	if *skipTLSVerify {
+		p.SetSkipTLSVerify(true)
+	}
+
 	var x509c *x509.Certificate
 	var priv interface{}
 
@@ -352,7 +356,6 @@ func main() {
 
 	stack.AddRequestModifier(logger)
 	stack.AddResponseModifier(logger)
-
 
 	if *marblLogging {
 		lsh := marbl.NewHandler()

--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -253,14 +253,14 @@ func main() {
 	p := martian.NewProxy()
 	defer p.Close()
 
-	mux := http.NewServeMux()
-
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: *skipTLSVerify,
 		},
 	}
 	p.SetRoundTripper(tr)
+
+	mux := http.NewServeMux()
 
 	var x509c *x509.Certificate
 	var priv interface{}

--- a/cmd/proxy/main_test.go
+++ b/cmd/proxy/main_test.go
@@ -33,18 +33,18 @@ import (
 	"github.com/google/martian/mitm"
 )
 
-func waitForProxy(t *testing.T, c *http.Client, apiURL string) {
+func waitForProxy(t *testing.T, c *http.Client, apiUrl string) {
 	timeout := 5 * time.Second
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		res, err := c.Get(apiURL)
+		res, err := c.Get(apiUrl)
 		if err != nil {
 			time.Sleep(200 * time.Millisecond)
 			continue
 		}
 		defer res.Body.Close()
 		if got, want := res.StatusCode, http.StatusOK; got != want {
-			t.Fatalf("waitForProxy: c.Get(%q): got status %d, want %d", apiURL, got, want)
+			t.Fatalf("waitForProxy: c.Get(%q): got status %d, want %d", apiUrl, got, want)
 		}
 		return
 	}
@@ -98,13 +98,13 @@ func TestProxy(t *testing.T) {
 		defer cmd.Wait()
 		defer cmd.Process.Signal(os.Interrupt)
 
-		proxyURL := "http://localhost" + proxyPort
-		apiURL := "http://localhost" + apiPort
-		configureURL := "http://martian.proxy/configure"
+		proxyUrl := "http://localhost" + proxyPort
+		apiUrl := "http://localhost" + apiPort
+		configureUrl := "http://martian.proxy/configure"
 
 		// TODO: Make using API hostport directly work on Travis.
-		apiClient := &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(parseURL(t, apiURL))}}
-		waitForProxy(t, apiClient, configureURL)
+		apiClient := &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(parseURL(t, apiUrl))}}
+		waitForProxy(t, apiClient, configureUrl)
 
 		// Configure modifiers
 		config := strings.NewReader(`
@@ -124,17 +124,17 @@ func TestProxy(t *testing.T) {
 			    ]
 			  }
 			}`)
-		res, err := apiClient.Post(configureURL, "application/json", config)
+		res, err := apiClient.Post(configureUrl, "application/json", config)
 		if err != nil {
-			t.Fatalf("apiClient.Post(%q): got error %v, want no error", configureURL, err)
+			t.Fatalf("apiClient.Post(%q): got error %v, want no error", configureUrl, err)
 		}
 		defer res.Body.Close()
 		if got, want := res.StatusCode, http.StatusOK; got != want {
-			t.Fatalf("apiClient.Post(%q): got status %d, want %d", configureURL, got, want)
+			t.Fatalf("apiClient.Post(%q): got status %d, want %d", configureUrl, got, want)
 		}
 
 		// Exercise proxy
-		client := &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(parseURL(t, proxyURL))}}
+		client := &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(parseURL(t, proxyUrl))}}
 
 		testUrl := "http://super.fake.domain/"
 		res, err = client.Get(testUrl)
@@ -191,13 +191,13 @@ func TestProxy(t *testing.T) {
 		defer cmd.Wait()
 		defer cmd.Process.Signal(os.Interrupt)
 
-		proxyURL := "http://localhost" + proxyPort
-		apiURL := "http://localhost" + apiPort
-		configureURL := "http://martian.proxy/configure"
+		proxyUrl := "http://localhost" + proxyPort
+		apiUrl := "http://localhost" + apiPort
+		configureUrl := "http://martian.proxy/configure"
 
 		// TODO: Make using API hostport directly work on Travis.
-		apiClient := &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(parseURL(t, apiURL))}}
-		waitForProxy(t, apiClient, configureURL)
+		apiClient := &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(parseURL(t, apiUrl))}}
+		waitForProxy(t, apiClient, configureUrl)
 
 		// Configure modifiers
 		config := strings.NewReader(fmt.Sprintf(`
@@ -208,13 +208,13 @@ func TestProxy(t *testing.T) {
 			    "body": "%s"
 			  }
 			}`, base64.StdEncoding.EncodeToString([]byte("茶壺"))))
-		res, err := apiClient.Post(configureURL, "application/json", config)
+		res, err := apiClient.Post(configureUrl, "application/json", config)
 		if err != nil {
-			t.Fatalf("apiClient.Post(%q): got error %v, want no error", configureURL, err)
+			t.Fatalf("apiClient.Post(%q): got error %v, want no error", configureUrl, err)
 		}
 		defer res.Body.Close()
 		if got, want := res.StatusCode, http.StatusOK; got != want {
-			t.Fatalf("apiClient.Post(%q): got status %d, want %d", configureURL, got, want)
+			t.Fatalf("apiClient.Post(%q): got status %d, want %d", configureUrl, got, want)
 		}
 
 		// Install proxy's CA cert into http client
@@ -233,7 +233,7 @@ func TestProxy(t *testing.T) {
 
 		// Exercise proxy
 		client := &http.Client{Transport: &http.Transport{
-			Proxy: http.ProxyURL(parseURL(t, proxyURL)),
+			Proxy: http.ProxyURL(parseURL(t, proxyUrl)),
 			TLSClientConfig: &tls.Config{
 				RootCAs: caCertPool,
 			},

--- a/cmd/proxy/main_test.go
+++ b/cmd/proxy/main_test.go
@@ -15,6 +15,10 @@
 package main
 
 import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"fmt"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -55,7 +59,7 @@ func getFreePort(t *testing.T) string {
 	return l.Addr().String()[strings.LastIndex(l.Addr().String(), ":"):]
 }
 
-func TestProxyHttp(t *testing.T) {
+func TestProxy(t *testing.T) {
 	tempDir, err := ioutil.TempDir("", t.Name())
 	if err != nil {
 		t.Fatal(err)
@@ -71,71 +75,161 @@ func TestProxyHttp(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Start proxy
-	proxyPort := getFreePort(t)
-	apiPort := getFreePort(t)
-	cmd = exec.Command(binPath, "-addr="+proxyPort, "-api-addr="+apiPort)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Start(); err != nil {
-		t.Fatal(err)
-	}
-	defer cmd.Wait()
-	defer cmd.Process.Signal(os.Interrupt)
+	t.Run("Http", func(t *testing.T) {
+		// Start proxy
+		proxyPort := getFreePort(t)
+		apiPort := getFreePort(t)
+		cmd = exec.Command(binPath, "-addr="+proxyPort, "-api-addr="+apiPort, "-v=3")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Start(); err != nil {
+			t.Fatal(err)
+		}
+		defer cmd.Wait()
+		defer cmd.Process.Signal(os.Interrupt)
 
-	proxyUrl := "http://localhost" + proxyPort
-	apiUrl := "http://localhost" + apiPort
-	configureUrl := "http://martian.proxy/configure"
+		proxyUrl := "http://localhost" + proxyPort
+		apiUrl := "http://localhost" + apiPort
+		configureUrl := "http://martian.proxy/configure"
 
-	au, err := url.Parse(apiUrl)
-	if err != nil {
-		t.Fatalf("url.Parse(%q): got error %v, want no error", apiUrl, err)
-	}
-	// TODO: Make using API hostport directly work on Travis.
-	apiClient := &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(au)}}
-	waitForProxy(t, apiClient, configureUrl)
+		au, err := url.Parse(apiUrl)
+		if err != nil {
+			t.Fatalf("url.Parse(%q): got error %v, want no error", apiUrl, err)
+		}
+		// TODO: Make using API hostport directly work on Travis.
+		apiClient := &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(au)}}
+		waitForProxy(t, apiClient, configureUrl)
 
-	// Configure modifiers
-	config := strings.NewReader(`
-		{
-		  "fifo.Group": {
-		    "scope": ["request", "response"],
-		    "modifiers": [
-		      {
-		        "status.Modifier": {
-		          "scope": ["response"],
-		          "statusCode": 418
-		        }
-		      },
-		      {
-		        "skip.RoundTrip": {}
-		      }
-		    ]
-		  }
-		}`)
-	res, err := apiClient.Post(configureUrl, "application/json", config)
-	if err != nil {
-		t.Fatalf("apiClient.Post(%q): got error %v, want no error", configureUrl, err)
-	}
-	defer res.Body.Close()
-	if got, want := res.StatusCode, http.StatusOK; got != want {
-		t.Fatalf("apiClient.Post(%q): got status %d, want %d", configureUrl, got, want)
-	}
+		// Configure modifiers
+		config := strings.NewReader(`
+			{
+			  "fifo.Group": {
+			    "scope": ["request", "response"],
+			    "modifiers": [
+			      {
+			        "status.Modifier": {
+			          "scope": ["response"],
+			          "statusCode": 418
+			        }
+			      },
+			      {
+			        "skip.RoundTrip": {}
+			      }
+			    ]
+			  }
+			}`)
+		res, err := apiClient.Post(configureUrl, "application/json", config)
+		if err != nil {
+			t.Fatalf("apiClient.Post(%q): got error %v, want no error", configureUrl, err)
+		}
+		defer res.Body.Close()
+		if got, want := res.StatusCode, http.StatusOK; got != want {
+			t.Fatalf("apiClient.Post(%q): got status %d, want %d", configureUrl, got, want)
+		}
 
-	// Exercise proxy
-	pu, err := url.Parse(proxyUrl)
-	if err != nil {
-		t.Fatalf("url.Parse(%q): got error %v, want no error", proxyUrl, err)
-	}
-	client := &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(pu)}}
+		// Exercise proxy
+		pu, err := url.Parse(proxyUrl)
+		if err != nil {
+			t.Fatalf("url.Parse(%q): got error %v, want no error", proxyUrl, err)
+		}
+		client := &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(pu)}}
 
-	testUrl := "http://super.fake.domain/"
-	res, err = client.Get(testUrl)
-	if err != nil {
-		t.Fatalf("client.Get(%q): got error %v, want no error", testUrl, err)
-	}
-	defer res.Body.Close()
-	if got, want := res.StatusCode, http.StatusTeapot; got != want {
-		t.Errorf("client.Get(%q): got status %d, want %d", testUrl, got, want)
-	}
+		testUrl := "http://super.fake.domain/"
+		res, err = client.Get(testUrl)
+		if err != nil {
+			t.Fatalf("client.Get(%q): got error %v, want no error", testUrl, err)
+		}
+		defer res.Body.Close()
+		if got, want := res.StatusCode, http.StatusTeapot; got != want {
+			t.Errorf("client.Get(%q): got status %d, want %d", testUrl, got, want)
+		}
+	})
+
+	t.Run("Https", func(t *testing.T) {
+		// Start proxy
+		proxyPort := getFreePort(t)
+		apiPort := getFreePort(t)
+		tlsPort := getFreePort(t)
+		cmd = exec.Command(binPath, "-addr="+proxyPort, "-api-addr="+apiPort, "-tls-addr="+tlsPort, "-generate-ca-cert", "-v=3")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Start(); err != nil {
+			t.Fatal(err)
+		}
+		defer cmd.Wait()
+		defer cmd.Process.Signal(os.Interrupt)
+
+		proxyUrl := "http://localhost" + proxyPort
+		apiUrl := "http://localhost" + apiPort
+		configureUrl := "http://martian.proxy/configure"
+
+		au, err := url.Parse(apiUrl)
+		if err != nil {
+			t.Fatalf("url.Parse(%q): got error %v, want no error", apiUrl, err)
+		}
+		// TODO: Make using API hostport directly work on Travis.
+		apiClient := &http.Client{Transport: &http.Transport{Proxy: http.ProxyURL(au)}}
+		waitForProxy(t, apiClient, configureUrl)
+
+		// Configure modifiers
+		config := strings.NewReader(fmt.Sprintf(`
+			{
+			  "body.Modifier": {
+			    "scope": ["response"],
+			    "contentType": "text/plain",
+			    "body": "%s"
+			  }
+			}`, base64.StdEncoding.EncodeToString([]byte("茶壺"))))
+		res, err := apiClient.Post(configureUrl, "application/json", config)
+		if err != nil {
+			t.Fatalf("apiClient.Post(%q): got error %v, want no error", configureUrl, err)
+		}
+		defer res.Body.Close()
+		if got, want := res.StatusCode, http.StatusOK; got != want {
+			t.Fatalf("apiClient.Post(%q): got status %d, want %d", configureUrl, got, want)
+		}
+
+		// Install CA cert into http client
+		caCertUrl := "http://martian.proxy/authority.cer"
+		res, err = apiClient.Get(caCertUrl)
+		if err != nil {
+			t.Fatalf("apiClient.Get(%q): got error %v, want no error", caCertUrl, err)
+		}
+		defer res.Body.Close()
+		caCert, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			t.Fatalf("ioutil.ReadAll(res.Body): got error %v, want no error", err)
+		}
+		caCertPool := x509.NewCertPool()
+		caCertPool.AppendCertsFromPEM(caCert)
+
+		// Exercise proxy
+		pu, err := url.Parse(proxyUrl)
+		if err != nil {
+			t.Fatalf("url.Parse(%q): got error %v, want no error", proxyUrl, err)
+		}
+		client := &http.Client{Transport: &http.Transport{
+			Proxy: http.ProxyURL(pu),
+			TLSClientConfig: &tls.Config{
+				RootCAs: caCertPool,
+			},
+		}}
+
+		testUrl := "https://www.google.com/"
+		res, err = client.Get(testUrl)
+		if err != nil {
+			t.Fatalf("client.Get(%q): got error %v, want no error", testUrl, err)
+		}
+		defer res.Body.Close()
+		if got, want := res.StatusCode, http.StatusOK; got != want {
+			t.Fatalf("client.Get(%q): got status %d, want %d", testUrl, got, want)
+		}
+		body, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			t.Fatalf("ioutil.ReadAll(res.Body): got error %v, want no error", err)
+		}
+		if got, want := string(body), "茶壺"; got != want {
+			t.Fatalf("modified response body: got %s, want %s", got, want)
+		}
+	})
 }

--- a/proxy.go
+++ b/proxy.go
@@ -113,6 +113,16 @@ func (p *Proxy) SetMITM(config *mitm.Config) {
 	p.mitm = config
 }
 
+// SetSkipTLSVerify configures whether the proxy skips verification of server certificates.
+func (p *Proxy) SetSkipTLSVerify(skip bool) {
+	if tr, ok := p.roundTripper.(*http.Transport); ok {
+		if tr.TLSClientConfig == nil {
+			tr.TLSClientConfig = &tls.Config{}
+		}
+		tr.TLSClientConfig.InsecureSkipVerify = skip
+	}
+}
+
 // Close sets the proxy to the closing state so it stops receiving new connections,
 // finishes processing any inflight requests, and closes existing connections without
 // reading anymore requests from them.

--- a/proxy.go
+++ b/proxy.go
@@ -113,16 +113,6 @@ func (p *Proxy) SetMITM(config *mitm.Config) {
 	p.mitm = config
 }
 
-// SetSkipTLSVerify configures whether the proxy skips verification of server certificates.
-func (p *Proxy) SetSkipTLSVerify(skip bool) {
-	if tr, ok := p.roundTripper.(*http.Transport); ok {
-		if tr.TLSClientConfig == nil {
-			tr.TLSClientConfig = &tls.Config{}
-		}
-		tr.TLSClientConfig.InsecureSkipVerify = skip
-	}
-}
-
 // Close sets the proxy to the closing state so it stops receiving new connections,
 // finishes processing any inflight requests, and closes existing connections without
 // reading anymore requests from them.


### PR DESCRIPTION
The -skip-tls-verify flag did not apply to the proxy's outbound connection. This change fixes that issue with an accompanying https integration test.
Also refactored the test.