### PR TITLE
Added failure verifier.

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -220,6 +220,7 @@ import (
 
 	_ "github.com/google/martian/body"
 	_ "github.com/google/martian/cookie"
+	_ "github.com/google/martian/failure"
 	_ "github.com/google/martian/martianurl"
 	_ "github.com/google/martian/method"
 	_ "github.com/google/martian/pingback"

--- a/failure/failure_verifier.go
+++ b/failure/failure_verifier.go
@@ -1,0 +1,98 @@
+// Copyright 2017 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package failure provides a verifier that always fails, adding a given message
+// to the multierror log. This can be used to turn any filter in to a defacto
+// verifier, by wrapping it in a filter and thus causing a verifier failure whenever
+// a request passes the filter.
+package failure
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/google/martian"
+	"github.com/google/martian/parse"
+	"github.com/google/martian/verify"
+)
+
+func init() {
+	parse.Register("failure.Verifier", verifierFromJSON)
+}
+
+type verifier struct {
+	message string
+	merr    *martian.MultiError
+}
+
+type verifierJSON struct {
+	Message string               `json:"message"`
+	Scope   []parse.ModifierType `json:"scope"`
+}
+
+// NewVerifier returns a new failing verifier.
+func NewVerifier(message string) (verify.RequestVerifier, error) {
+	return &verifier{
+		message: message,
+		merr:    martian.NewMultiError(),
+	}, nil
+}
+
+// ModifyRequest adds an error message containing the message field in the verifier to the verifier errors.
+// This means that any time a request hits the verifier it's treated as an error.
+func (v *verifier) ModifyRequest(req *http.Request) error {
+	err := fmt.Errorf("request(%v) verification error: %s", req.URL, v.message)
+	v.merr.Add(err)
+	return nil
+}
+
+// VerifyRequests returns an error if any requests have hit the verifier.
+// If an error is returned it will be of type *martian.MultiError.
+func (v *verifier) VerifyRequests() error {
+	if v.merr.Empty() {
+		return nil
+	}
+
+	return v.merr
+}
+
+// ResetRequestVerifications clears all failed request verifications.
+func (v *verifier) ResetRequestVerifications() {
+	v.merr = martian.NewMultiError()
+}
+
+// verifierFromJSON builds a failure.Verifier from JSON
+//
+// Example JSON:
+// {
+//   "failure.Verifier": {
+//     "scope": ["request", "response"],
+//     "message": "Request passed a filter it should not have"
+//   }
+// }
+
+func verifierFromJSON(b []byte) (*parse.Result, error) {
+	msg := &verifierJSON{}
+	if err := json.Unmarshal(b, msg); err != nil {
+		return nil, err
+	}
+
+	v, err := NewVerifier(msg.Message)
+	if err != nil {
+		return nil, err
+	}
+
+	return parse.NewResult(v, msg.Scope)
+}

--- a/failure/failure_verifier.go
+++ b/failure/failure_verifier.go
@@ -82,7 +82,6 @@ func (v *verifier) ResetRequestVerifications() {
 //     "message": "Request passed a filter it should not have"
 //   }
 // }
-
 func verifierFromJSON(b []byte) (*parse.Result, error) {
 	msg := &verifierJSON{}
 	if err := json.Unmarshal(b, msg); err != nil {

--- a/failure/failure_verifier_test.go
+++ b/failure/failure_verifier_test.go
@@ -82,11 +82,11 @@ func TestFailureWithMultiFail(t *testing.T) {
 
 func TestVerifierFromJSON(t *testing.T) {
 	msg := []byte(`{
-    	"failure.Verifier": {
-      		"scope": ["request"],
-      		"message": "foo"
-    		}
-  		}`)
+		"failure.Verifier": {
+			"scope": ["request"],
+			"message": "foo"
+		}
+	}`)
 
 	r, err := parse.FromJSON(msg)
 	if err != nil {

--- a/failure/failure_verifier_test.go
+++ b/failure/failure_verifier_test.go
@@ -82,11 +82,11 @@ func TestFailureWithMultiFail(t *testing.T) {
 
 func TestVerifierFromJSON(t *testing.T) {
 	msg := []byte(`{
-    "failure.Verifier": {
-      "scope": ["request"],
-      "message": "foo"
-    }
-  }`)
+    	"failure.Verifier": {
+      		"scope": ["request"],
+      		"message": "foo"
+    		}
+  		}`)
 
 	r, err := parse.FromJSON(msg)
 	if err != nil {

--- a/failure/failure_verifier_test.go
+++ b/failure/failure_verifier_test.go
@@ -1,0 +1,114 @@
+// Copyright 2017 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package failure
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/google/martian"
+	"github.com/google/martian/parse"
+	"github.com/google/martian/verify"
+)
+
+func TestVerifyRequestFails(t *testing.T) {
+	v, err := NewVerifier("foo")
+	if err != nil {
+		t.Fatalf("NewVerifier(%q): got %v, want no error", "foo", err)
+	}
+
+	req, err := http.NewRequest("GET", "http://www.google.com", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest(): got %v, want no error", err)
+	}
+
+	if err := v.ModifyRequest(req); err != nil {
+		t.Fatalf("ModifyRequest(): got %v, want no error", err)
+	}
+	if err := v.VerifyRequests(); err == nil {
+		t.Fatalf("VerifyRequests(): got no error, want *verify.MultiError")
+	}
+}
+
+func TestFailureWithMultiFail(t *testing.T) {
+	v, err := NewVerifier("foo")
+	if err != nil {
+		t.Fatalf("NewVerifier(%q): got %v, want no error", "foo", err)
+	}
+	req, err := http.NewRequest("GET", "http://www.google.com", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest(): got %v, want no error", err)
+	}
+	if err := v.ModifyRequest(req); err != nil {
+		t.Fatalf("ModifyRequest(): got %v, want no error", err)
+	}
+	if err := v.ModifyRequest(req); err != nil {
+		t.Fatalf("ModifyRequest(): got %v, want no error", err)
+	}
+	merr, ok := v.VerifyRequests().(*martian.MultiError)
+	if !ok {
+		t.Fatalf("VerifyRequests(): got nil, want *verify.MultiError")
+	}
+
+	errs := merr.Errors()
+	if len(errs) != 2 {
+		t.Fatalf("len(merr.Errors()): got %d, want 2", len(errs))
+	}
+
+	expectErr := "request(http://www.google.com) verification error: foo"
+	for i := range errs {
+		if got, want := errs[i].Error(), expectErr; got != want {
+			t.Errorf("%d. err.Error(): mismatched error output\ngot: %s\nwant: %s", i,
+				got, want)
+		}
+	}
+	v.ResetRequestVerifications()
+	if err := v.VerifyRequests(); err != nil {
+		t.Fatalf("VerifyRequests(): got %v, want no error", err)
+	}
+}
+
+func TestVerifierFromJSON(t *testing.T) {
+	msg := []byte(`{
+    "failure.Verifier": {
+      "scope": ["request"],
+      "message": "foo"
+    }
+  }`)
+
+	r, err := parse.FromJSON(msg)
+	if err != nil {
+		t.Fatalf("parse.FromJSON(): got %v, want no error", err)
+	}
+	reqmod := r.RequestModifier()
+	if reqmod == nil {
+		t.Fatal("reqmod: got nil, want not nil")
+	}
+	reqv, ok := reqmod.(verify.RequestVerifier)
+	if !ok {
+		t.Fatal("reqmod.(verify.RequestVerifier): got !ok, want ok")
+	}
+
+	req, err := http.NewRequest("GET", "http://example.com", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest(): got %v, want no error", err)
+	}
+	if err := reqv.ModifyRequest(req); err != nil {
+		t.Fatalf("ModifyRequest(): got %v, want no error", err)
+	}
+	if err := reqv.VerifyRequests(); err == nil {
+		t.Error("VerifyRequests(): got nil, want not nil")
+	}
+}

--- a/mobile/proxy.go
+++ b/mobile/proxy.go
@@ -41,6 +41,7 @@ import (
 	// side-effect importing to register with JSON API
 	_ "github.com/google/martian/body"
 	_ "github.com/google/martian/cookie"
+	_ "github.com/google/martian/failure"
 	_ "github.com/google/martian/header"
 	_ "github.com/google/martian/martianurl"
 	_ "github.com/google/martian/method"


### PR DESCRIPTION
This is a verifier that you can initialize with an error message, and will fail for any request that hits it. By wrapping it in a filter, you can effectively turn any filter into verifier that will log an error to /verify.