### PR TITLE
mobile/proxy API can be served over TLS 

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -334,7 +334,7 @@ func main() {
 
 	if *harLogging {
 		hl := har.NewLogger()
-		muxf := servemux.NewFilter(nil)
+		muxf := servemux.NewFilter(mux)
 		// Only append to HAR logs when the requests are not API requests,
 		// that is, they are not matched in http.DefaultServeMux
 		muxf.RequestWhenFalse(hl)
@@ -356,14 +356,14 @@ func main() {
 	if *marblLogging {
 		lsh := marbl.NewHandler()
 		lsm := marbl.NewModifier(lsh)
-		muxf := servemux.NewFilter(nil)
+		muxf := servemux.NewFilter(mux)
 		muxf.RequestWhenFalse(lsm)
 		muxf.ResponseWhenFalse(lsm)
 		stack.AddRequestModifier(muxf)
 		stack.AddResponseModifier(muxf)
 
 		// retrieve binary marbl logs
-		http.Handle("/binlogs", lsh)
+		mux.Handle("/binlogs", lsh)
 	}
 
 	// Configure modifiers.

--- a/mobile/proxy.go
+++ b/mobile/proxy.go
@@ -18,9 +18,11 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
+	"os"
 	"path"
 	"time"
 
@@ -64,9 +66,10 @@ type Martian struct {
 	listener    net.Listener
 	mux         *http.ServeMux
 	started     bool
-	HarLogging  bool
+	HARLogging  bool
 	TrafficPort int
 	APIPort     int
+	APIOverTLS  bool
 	Cert        string
 	Key         string
 	AllowCORS   bool
@@ -137,7 +140,7 @@ func (m *Martian) Start() {
 	m.proxy.SetRequestModifier(topg)
 	m.proxy.SetResponseModifier(topg)
 
-	if m.HarLogging {
+	if m.HARLogging {
 		// add HAR logger for unmodified logs.
 		uhl := har.NewLogger()
 		uhmuxf := servemux.NewFilter(m.mux)
@@ -202,6 +205,41 @@ func (m *Martian) Start() {
 
 	// start the API server
 	apiAddr := fmt.Sprintf(":%d", m.APIPort)
+	if m.APIOverTLS {
+		if m.Cert == "" || m.Key == "" {
+			log.Fatal("mobile: APIOverTLS cannot be true without valid cert and key")
+		}
+
+		cerfile, err := ioutil.TempFile("", "martian-api.cert")
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		keyfile, err := ioutil.TempFile("", "martian-api.key")
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if _, err := cerfile.Write([]byte(m.Cert)); err != nil {
+			log.Fatal(err)
+		}
+
+		if _, err := keyfile.Write([]byte(m.Key)); err != nil {
+			log.Fatal(err)
+		}
+
+		go func() {
+			http.ListenAndServeTLS(apiAddr, cerfile.Name(), keyfile.Name(), m.mux)
+			defer os.Remove(cerfile.Name())
+			defer os.Remove(keyfile.Name())
+		}()
+
+		mlog.Infof("mobile: proxy API started on %s over TLS", apiAddr)
+	} else {
+		go http.ListenAndServe(apiAddr, m.mux)
+		mlog.Infof("mobile: proxy API started on %s", apiAddr)
+	}
+
 	go http.ListenAndServe(apiAddr, m.mux)
 	mlog.Infof("mobile: proxy API started on %s", apiAddr)
 	m.started = true

--- a/mobile/proxy.go
+++ b/mobile/proxy.go
@@ -123,7 +123,7 @@ func (m *Martian) Start() {
 		m.handle("/authority.cer", martianhttp.NewAuthorityHandler(x509c))
 	}
 
-	// Forward traffic that pattern matches in http.DefaultServeMux before applying
+	// Forward traffic that pattern matches in m.mux before applying
 	// httpspec modifiers (via modifier, specifically)
 	topg := fifo.NewGroup()
 	apif := servemux.NewFilter(m.mux)

--- a/mobile/proxy.go
+++ b/mobile/proxy.go
@@ -126,7 +126,7 @@ func (m *Martian) Start() {
 	// Forward traffic that pattern matches in http.DefaultServeMux before applying
 	// httpspec modifiers (via modifier, specifically)
 	topg := fifo.NewGroup()
-	apif := servemux.NewFilter(nil)
+	apif := servemux.NewFilter(m.mux)
 	apif.SetRequestModifier(api.NewForwarder("", m.APIPort))
 	topg.AddRequestModifier(apif)
 


### PR DESCRIPTION
since ListenAndServeTLS requires the path the the cert and key files, this change writes the cert and key to a temp directory.