### PR TITLE
add reset and export functionality to HAR logs

### DIFF
--- a/har/har.go
+++ b/har/har.go
@@ -19,13 +19,13 @@
 package har
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 	"mime"
 	"mime/multipart"
 	"net/http"
 	"net/url"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -45,6 +45,7 @@ type Logger struct {
 
 	mu      sync.Mutex
 	entries map[string]*Entry
+	tail    *Entry
 }
 
 // HAR is the top level object of a HAR log.
@@ -87,6 +88,7 @@ type Entry struct {
 	// Timings describes various phases within request-response round trip. All
 	// times are specified in milliseconds.
 	Timings *Timings `json:"timings"`
+	next    *Entry
 }
 
 // Request holds data about an individual HTTP request.
@@ -371,15 +373,28 @@ func (l *Logger) RecordRequest(id string, req *http.Request) error {
 		return err
 	}
 
-	l.mu.Lock()
-	defer l.mu.Unlock()
-
-	l.entries[id] = &Entry{
+	entry := &Entry{
 		ID:              id,
 		StartedDateTime: time.Now().UTC(),
 		Request:         hreq,
 		Cache:           &Cache{},
 		Timings:         &Timings{},
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if _, exists := l.entries[id]; exists {
+		return fmt.Errorf("Duplicate request ID: %s", id)
+	}
+	l.entries[id] = entry
+	if l.tail == nil {
+		l.tail = entry
+		l.tail.next = entry
+	} else {
+		entry.next = l.tail.next
+		l.tail.next = entry
+		l.tail = entry
 	}
 
 	return nil
@@ -501,12 +516,54 @@ func (l *Logger) Export() *HAR {
 	defer l.mu.Unlock()
 
 	es := make([]*Entry, 0, len(l.entries))
-	for _, e := range l.entries {
-		es = append(es, e)
+	curr := l.tail
+	for curr != nil {
+		curr = curr.next
+		es = append(es, curr)
+		if curr == l.tail {
+			break
+		}
 	}
 
-	sort.Sort(byRequestDate(es))
+	return l.makeHAR(es)
+}
 
+// ExportAndReset returns the in-memory log for completed requests, clearing them.
+func (l *Logger) ExportAndReset() *HAR {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	es := make([]*Entry, 0, len(l.entries))
+	curr := l.tail
+	prev := l.tail
+	var first *Entry
+	for curr != nil {
+		curr = curr.next
+		if curr.Response != nil {
+			es = append(es, curr)
+			delete(l.entries, curr.ID)
+		} else {
+			if first == nil {
+				first = curr
+			}
+			prev.next = curr
+			prev = curr
+		}
+		if curr == l.tail {
+			break
+		}
+	}
+	if len(l.entries) == 0 {
+		l.tail = nil
+	} else {
+		l.tail = prev
+		l.tail.next = first
+	}
+
+	return l.makeHAR(es)
+}
+
+func (l *Logger) makeHAR(es []*Entry) *HAR {
 	return &HAR{
 		Log: &Log{
 			Version: "1.2",
@@ -522,6 +579,7 @@ func (l *Logger) Reset() {
 	defer l.mu.Unlock()
 
 	l.entries = make(map[string]*Entry)
+	l.tail = nil
 }
 
 func cookies(cs []*http.Cookie) []Cookie {
@@ -649,17 +707,4 @@ func postData(req *http.Request, logBody bool) (*PostData, error) {
 	}
 
 	return pd, nil
-}
-
-type byRequestDate []*Entry
-
-// Len returns the length of the slice of entries.
-func (e byRequestDate) Len() int { return len(e) }
-
-// Swap swaps entries by position.
-func (e byRequestDate) Swap(i, j int) { e[i], e[j] = e[j], e[i] }
-
-// Less returns whether the entry at i has a StartedDateTime before the entry at j.
-func (e byRequestDate) Less(i, j int) bool {
-	return e[i].StartedDateTime.Before(e[j].StartedDateTime)
 }

--- a/har/har.go
+++ b/har/har.go
@@ -391,11 +391,10 @@ func (l *Logger) RecordRequest(id string, req *http.Request) error {
 	if l.tail == nil {
 		l.tail = entry
 		l.tail.next = entry
-	} else {
-		entry.next = l.tail.next
-		l.tail.next = entry
-		l.tail = entry
 	}
+	entry.next = l.tail.next
+	l.tail.next = entry
+	l.tail = entry
 
 	return nil
 }

--- a/har/har.go
+++ b/har/har.go
@@ -390,7 +390,6 @@ func (l *Logger) RecordRequest(id string, req *http.Request) error {
 	l.entries[id] = entry
 	if l.tail == nil {
 		l.tail = entry
-		l.tail.next = entry
 	}
 	entry.next = l.tail.next
 	l.tail.next = entry

--- a/har/har_handlers.go
+++ b/har/har_handlers.go
@@ -17,6 +17,7 @@ package har
 import (
 	"encoding/json"
 	"net/http"
+	"net/url"
 	"strconv"
 
 	"github.com/google/martian/log"
@@ -69,7 +70,14 @@ func (h *resetHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if v, _ := strconv.ParseBool(req.URL.Query().Get("return")); v {
+
+	v, err := parseBoolQueryParam(req.URL.Query(), "return")
+	if err != nil {
+		log.Errorf("har: invalid value for return param: %s", err)
+		rw.WriteHeader(http.StatusBadRequest)
+	}
+
+	if v {
 		rw.Header().Set("Content-Type", "application/json; charset=utf-8")
 		hl := h.logger.ExportAndReset()
 		json.NewEncoder(rw).Encode(hl)
@@ -79,4 +87,15 @@ func (h *resetHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	log.Infof("resetHandler.ServeHTTP: HAR logs cleared")
+}
+
+func parseBoolQueryParam(params url.Values, name string) (bool, error) {
+	if params[name] == nil {
+		return false, nil
+	}
+	v, err := strconv.ParseBool(params.Get("return"))
+	if err != nil {
+		return true, err
+	}
+	return v, nil
 }

--- a/har/har_handlers.go
+++ b/har/har_handlers.go
@@ -69,7 +69,7 @@ func (h *resetHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	if isBool, _ := strconv.ParseBool(req.URL.Query().Get("return")); isBool {
+	if v, _ := strconv.ParseBool(req.URL.Query().Get("return")); v {
 		rw.Header().Set("Content-Type", "application/json; charset=utf-8")
 		hl := h.logger.ExportAndReset()
 		json.NewEncoder(rw).Encode(hl)

--- a/har/har_handlers.go
+++ b/har/har_handlers.go
@@ -17,6 +17,7 @@ package har
 import (
 	"encoding/json"
 	"net/http"
+	"strconv"
 
 	"github.com/google/martian/log"
 )
@@ -67,9 +68,15 @@ func (h *resetHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		log.Errorf("har: method not allowed: %s", req.Method)
 		return
 	}
-	h.logger.Reset()
+
+	if isBool, _ := strconv.ParseBool(req.URL.Query().Get("return")); isBool {
+		rw.Header().Set("Content-Type", "application/json; charset=utf-8")
+		hl := h.logger.ExportAndReset()
+		json.NewEncoder(rw).Encode(hl)
+	} else {
+		h.logger.Reset()
+		rw.WriteHeader(http.StatusNoContent)
+	}
 
 	log.Infof("resetHandler.ServeHTTP: HAR logs cleared")
-
-	rw.WriteHeader(http.StatusNoContent)
 }

--- a/har/har_handlers.go
+++ b/har/har_handlers.go
@@ -75,6 +75,7 @@ func (h *resetHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	if err != nil {
 		log.Errorf("har: invalid value for return param: %s", err)
 		rw.WriteHeader(http.StatusBadRequest)
+		return
 	}
 
 	if v {
@@ -95,7 +96,7 @@ func parseBoolQueryParam(params url.Values, name string) (bool, error) {
 	}
 	v, err := strconv.ParseBool(params.Get("return"))
 	if err != nil {
-		return true, err
+		return false, err
 	}
 	return v, nil
 }

--- a/har/har_handlers_test.go
+++ b/har/har_handlers_test.go
@@ -105,4 +105,35 @@ func TestExportHandlerServeHTTP(t *testing.T) {
 	if got, want := len(hl.Log.Entries), 0; got != want {
 		t.Errorf("len(Log.Entries): got %v, want %v", got, want)
 	}
+
+	req, err = http.NewRequest("DELETE", "/?return=1", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest(): got %v, want no error", err)
+	}
+
+	rw = httptest.NewRecorder()
+	rh.ServeHTTP(rw, req)
+	if got, want := rw.Code, http.StatusOK; got != want {
+		t.Errorf("rw.Code: got %d, want %d", got, want)
+	}
+
+	hl = &HAR{}
+	if err := json.Unmarshal(rw.Body.Bytes(), hl); err != nil {
+		t.Fatalf("json.Unmarshal(): got %v, want no error", err)
+	}
+
+	if got, want := len(hl.Log.Entries), 0; got != want {
+		t.Errorf("len(Log.Entries): got %v, want %v", got, want)
+	}
+
+	req, err = http.NewRequest("DELETE", "/?return=0", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest(): got %v, want no error", err)
+	}
+
+	rw = httptest.NewRecorder()
+	rh.ServeHTTP(rw, req)
+	if got, want := rw.Code, http.StatusNoContent; got != want {
+		t.Errorf("rw.Code: got %d, want %d", got, want)
+	}
 }

--- a/har/har_handlers_test.go
+++ b/har/har_handlers_test.go
@@ -136,4 +136,15 @@ func TestExportHandlerServeHTTP(t *testing.T) {
 	if got, want := rw.Code, http.StatusNoContent; got != want {
 		t.Errorf("rw.Code: got %d, want %d", got, want)
 	}
+
+	req, err = http.NewRequest("DELETE", "/?return=notboolean", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest(): got %v, want no error", err)
+	}
+
+	rw = httptest.NewRecorder()
+	rh.ServeHTTP(rw, req)
+	if got, want := rw.Code, http.StatusBadRequest; got != want {
+		t.Errorf("rw.Code: got %d, want %d", got, want)
+	}
 }


### PR DESCRIPTION
Currently there's no way to tail the martian logs (except with the MARBL WebSocket endpoint), which limits the use of Martian for long running tests that move lots of data over HTTP.
The `GET /logs` && `DELETE /logs/reset` functionality comes close, but is not atomic, discards responses to in flight requests from the log and scales `O(n*log(n))` with the batch size due to a sort.

This PR:
- Links `Entry` structs into a list that maintains insertion order which removes the need for sorting
- Adds a `?return=1` option to the reset endpoint that returns the completed request/response pairs, leaving behind all in flight requests.
- Preserves the normal functionality of the reset endpoint (all requests are purged including requests without responses).