### PR TITLE
fix martian/mobile shutdown leaving API socket

### DIFF
--- a/mobile/proxy.go
+++ b/mobile/proxy.go
@@ -61,7 +61,7 @@ import (
 type Martian struct {
 	proxy        *martian.Proxy
 	listener     net.Listener
-	APIListener  net.Listener
+	apiListener  net.Listener
 	mux          *http.ServeMux
 	started      bool
 	HARLogging   bool
@@ -207,7 +207,7 @@ func (m *Martian) Start() {
 
 	// start the API server
 	apiAddr := fmt.Sprintf(":%d", m.APIPort)
-	m.APIListener, err = net.Listen("tcp", apiAddr)
+	m.apiListener, err = net.Listen("tcp", apiAddr)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -235,14 +235,14 @@ func (m *Martian) Start() {
 		}
 
 		go func() {
-			http.ServeTLS(m.APIListener, m.mux, cerfile.Name(), keyfile.Name())
+			http.ServeTLS(m.apiListener, m.mux, cerfile.Name(), keyfile.Name())
 			defer os.Remove(cerfile.Name())
 			defer os.Remove(keyfile.Name())
 		}()
 
 		mlog.Infof("mobile: proxy API started on %s over TLS", apiAddr)
 	} else {
-		go http.Serve(m.APIListener, m.mux)
+		go http.Serve(m.apiListener, m.mux)
 		mlog.Infof("mobile: proxy API started on %s", apiAddr)
 	}
 
@@ -260,7 +260,7 @@ func (m *Martian) IsStarted() bool {
 func (m *Martian) Shutdown() {
 	mlog.Infof("mobile: shutting down proxy")
 	m.listener.Close()
-	m.APIListener.Close()
+	m.apiListener.Close()
 	m.proxy.Close()
 	m.started = false
 	mlog.Infof("mobile: proxy shut down")

--- a/mobile/proxy.go
+++ b/mobile/proxy.go
@@ -61,6 +61,7 @@ import (
 type Martian struct {
 	proxy        *martian.Proxy
 	listener     net.Listener
+	APIListener  net.Listener
 	mux          *http.ServeMux
 	started      bool
 	HARLogging   bool
@@ -206,6 +207,10 @@ func (m *Martian) Start() {
 
 	// start the API server
 	apiAddr := fmt.Sprintf(":%d", m.APIPort)
+	m.APIListener, err = net.Listen("tcp", apiAddr)
+	if err != nil {
+		log.Fatal(err)
+	}
 	if m.APIOverTLS {
 		if m.Cert == "" || m.Key == "" {
 			log.Fatal("mobile: APIOverTLS cannot be true without valid cert and key")
@@ -230,19 +235,17 @@ func (m *Martian) Start() {
 		}
 
 		go func() {
-			http.ListenAndServeTLS(apiAddr, cerfile.Name(), keyfile.Name(), m.mux)
+			http.ServeTLS(m.APIListener, m.mux, cerfile.Name(), keyfile.Name())
 			defer os.Remove(cerfile.Name())
 			defer os.Remove(keyfile.Name())
 		}()
 
 		mlog.Infof("mobile: proxy API started on %s over TLS", apiAddr)
 	} else {
-		go http.ListenAndServe(apiAddr, m.mux)
+		go http.Serve(m.APIListener, m.mux)
 		mlog.Infof("mobile: proxy API started on %s", apiAddr)
 	}
 
-	go http.ListenAndServe(apiAddr, m.mux)
-	mlog.Infof("mobile: proxy API started on %s", apiAddr)
 	m.started = true
 }
 
@@ -257,6 +260,7 @@ func (m *Martian) IsStarted() bool {
 func (m *Martian) Shutdown() {
 	mlog.Infof("mobile: shutting down proxy")
 	m.listener.Close()
+	m.APIListener.Close()
 	m.proxy.Close()
 	m.started = false
 	mlog.Infof("mobile: proxy shut down")


### PR DESCRIPTION
Martian.Shutdown() does not actually shut down all of the listening sockets that Start() binds