### PR TITLE
suppress SIGPIPE on Darwin

### DIFF
--- a/nosigpipe/nosigpipe.go
+++ b/nosigpipe/nosigpipe.go
@@ -1,0 +1,8 @@
+//+build !darwin !go1.9
+
+package nosigpipe
+
+import "net"
+
+func IgnoreSIGPIPE(c net.Conn) {
+}

--- a/nosigpipe/nosigpipe_darwin.go
+++ b/nosigpipe/nosigpipe_darwin.go
@@ -1,0 +1,35 @@
+//+build darwin,go1.9
+
+package nosigpipe
+
+import (
+	"github.com/google/martian/log"
+	"net"
+	"syscall"
+)
+
+// Prevent SIGPIPE from being raised on TCP sockets when remote hangs up
+// See: https://github.com/golang/go/issues/17393
+func IgnoreSIGPIPE(c net.Conn) {
+	if c == nil {
+		return
+	}
+	s, ok := c.(syscall.Conn)
+	if !ok {
+		return
+	}
+	r, e := s.SyscallConn()
+	if e != nil {
+		log.Errorf("Failed to get SyscallConn: %s", e)
+		return
+	}
+	e = r.Control(func(fd uintptr) {
+		intfd := int(fd)
+		if e := syscall.SetsockoptInt(intfd, syscall.SOL_SOCKET, syscall.SO_NOSIGPIPE, 1); e != nil {
+			log.Errorf("Failed to set SO_NOSIGPIPE: %s", e)
+		}
+	})
+	if e != nil {
+		log.Errorf("Failed to set SO_NOSIGPIPE: %s", e)
+	}
+}


### PR DESCRIPTION
When doing iOS development a SIGPIPE pauses Xcode whenever Martian attempts to write to a socket after an HTTP client has hung-up.

golang 1.9 introduces a new mechanism for accessing the underlying file descriptors, which allows us to set `SO_NOSIGPIPE` on the socket.

![screen shot 2018-03-19 at 6 29 45 pm](https://user-images.githubusercontent.com/6812536/37630763-8f7ea6a6-2ba3-11e8-8396-3d300c9d1d17.png)
