### PR TITLE
encode MARBL url-component pseudo-headers consistently

### DIFF
--- a/marbl/marbl.go
+++ b/marbl/marbl.go
@@ -157,7 +157,7 @@ func (s *Stream) LogRequest(id string, req *http.Request) error {
 	s.sendHeader(id, Request, ":method", req.Method)
 	s.sendHeader(id, Request, ":scheme", req.URL.Scheme)
 	s.sendHeader(id, Request, ":authority", req.URL.Host)
-	s.sendHeader(id, Request, ":path", req.URL.Path)
+	s.sendHeader(id, Request, ":path", req.URL.EscapedPath())
 	s.sendHeader(id, Request, ":query", req.URL.RawQuery)
 	s.sendHeader(id, Request, ":proto", req.Proto)
 	s.sendHeader(id, Request, ":remote", req.RemoteAddr)


### PR DESCRIPTION
Currently the `:path` and `:query` MARBL headers come back inconsistently with the query URL-encoded and the path decoded.

### Currently
`http://example.com/foo%20bar?baz%20qux` turns into `:path: /foo bar` and `:query: baz%20qux`

### With this PR
`http://example.com/foo%20bar?baz%20qux` turns into `:path: /foo%20bar` and `:query: baz%20qux`