### PR TITLE
Other projects use the notation GitHub, but this project was fixed as Github.

### DIFF
--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -17,7 +17,7 @@ frustration later on.
 
 ### Code reviews
 All submissions, including submissions by project members, require review. We
-use Github pull requests for this purpose.
+use GitHub pull requests for this purpose.
 
 ### The small print
 Contributions made by corporations are covered by a different agreement than


### PR DESCRIPTION
Hi. I use Google services frequently.

I'm a favorite company and I hope to contribute to Google. This time, I will send you PR because I found a point that I can correct about the notation of `Github`.

Other projects use the notation `GitHub`, but this project was fixed as` Github`

thank you.