### PR TITLE
bump required version of go

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: go
 
 go:
-  - tip
+  - 1.8.x
+  - 1.9.x
+  - 1.10.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: go
 
 go:
-  - 1.8.x
   - 1.9.x
   - 1.10.x

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ anywhere that Go can target.
 
 ## Requirements
 
-Go 1.8
+Go 1.9
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ anywhere that Go can target.
 
 ## Requirements
 
-Go 1.6
+Go 1.8
 
 ## Getting Started
 


### PR DESCRIPTION
[sort.SliceStable](https://github.com/google/martian/blob/a0d62b8f5af8847d8f523c33f45e509b390383f1/trafficshape/utils.go#L183) and [http.ServeTLS](https://github.com/google/martian/blob/a0d62b8f5af8847d8f523c33f45e509b390383f1/mobile/proxy.go#L249) are go 1.8 only.

The former can be solved with:

```
-               sort.SliceStable(shape.Throttles, func(i, j int) bool {
-                       return shape.Throttles[i].ByteStart < shape.Throttles[j].ByteStart
-                       })
+               sort.Sort(ByByteStart(shape.Throttles))

                defaultBandwidth := DefaultBitrate / 8
                if shape.MaxBandwidth > 0 {
@@ -196,8 +194,19 @@ func parseShapes(ts *Trafficshape) error {
                shape.Actions = append(shape.Actions, throttleActions...)

                // Sort the actions according to their byte offset.
-               sort.SliceStable(shape.Actions, func(i, j int) bool { return shape.Actions[i].getByte() < shape.Actions[j].getByte() })
+               sort.Sort(ByByte(shape.Actions))
        }
        return nil
 }

+type ByByteStart []*Throttle
+
+func (a ByByteStart) Len() int           { return len(a) }
+func (a ByByteStart) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a ByByteStart) Less(i, j int) bool { return a[i].ByteStart < a[j].ByteStart }
+
+type ByByte []Action
+
+func (a ByByte) Len() int           { return len(a) }
+func (a ByByte) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a ByByte) Less(i, j int) bool { return a[i].getByte() < a[j].getByte() }
```

The latter is harder to solve. I'm not sure if the intent of this library is to be 1.6 compatible, in which case I'm happy to close this and re-open as an issue. The current case, though, is 1.8+ compatibility, so this PR codifies that.