### PR TITLE
Fix marbl test flake by adding a short sleep and failing fast.

### DIFF
--- a/marbl/handler.go
+++ b/marbl/handler.go
@@ -44,15 +44,20 @@ func (h *Handler) Write(b []byte) (int, error) {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 
+	var wg sync.WaitGroup
 	for id, framec := range h.subs {
-		select {
-		case framec <- b:
-		default:
-			log.Errorf("logstream: buffer full for connection, dropping")
-			close(framec)
-			delete(h.subs, id)
-		}
+		wg.Add(1)
+		go func(id string, framec chan<- []byte) {
+			defer wg.Done()
+			select {
+			case framec <- b:
+			default:
+				log.Errorf("logstream: buffer full for connection, dropping")
+				go h.unsubscribe(id)
+			}
+		}(id, framec)
 	}
+	wg.Wait()
 
 	return len(b), nil
 }
@@ -95,12 +100,22 @@ func (h *Handler) unsubscribe(id string) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	delete(h.subs, id)
+	if framec, ok := h.subs[id]; ok {
+		close(framec)
+		delete(h.subs, id)
+	}
 }
 
 func (h *Handler) subscribe(id string, framec chan<- []byte) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
+	if framec, ok := h.subs[id]; ok {
+		// TODO: Re-pick the id.
+		log.Errorf("Resubscribing with ID: %v", id)
+		// Close the channel for now so the websocket gets disconnected,
+		// instead of silently failing.
+		close(framec)
+	}
 	h.subs[id] = framec
 }

--- a/marbl/handler_test.go
+++ b/marbl/handler_test.go
@@ -42,7 +42,7 @@ func TestStreamsInSentOrder(t *testing.T) {
 	defer ws.Close()
 
 	// Gives handler time to create the subscription channel.
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(200 * time.Millisecond)
 
 	var iterations int64 = 5000
 	go func() {
@@ -84,7 +84,7 @@ func TestUnreadsDontBlock(t *testing.T) {
 	defer ws.Close()
 
 	// Gives handler time to create the subscription channel.
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(200 * time.Millisecond)
 
 	bytes := make([]byte, 1024)
 	_, err = rand.Read(bytes)
@@ -94,7 +94,7 @@ func TestUnreadsDontBlock(t *testing.T) {
 	// Purposely using more iterations than frame channel size.
 	var iterations int64 = 50000
 	for i := int64(0); i < iterations; i++ {
-		to := doOrTimeout(1*time.Second, func() {
+		to := doOrTimeout(3*time.Second, func() {
 			handler.Write(bytes)
 		})
 		if to {


### PR DESCRIPTION
Fix for issue #282.  The flake was caused by a race condition between subscribing the frame channel during websocket connection creation and the first write happening.  The test starts writing to the handler as soon as the websocket is connected, but there is a delay between the websocket being created and when a channel is created and subscribed.  If writes happen before the channel is subscribed, those writes don't get propagated to the websocket.  This should fail the test, but the test used t.Errorf(), which only records the failure and continues the test.  Because those initial writes were lost, the test ends up reading fewer messages than was sent and keeps waiting for more messages that will never arrive, thereby hanging the test.

The solution is to add a short sleep before the test begins writing to the handler.  Also changing t.Errorf() to t.Fatalf() makes the test fail fast and not wait for more messages.

This commit also fixes an unsafe map entry deletion in Write() that didn't hold a exclusive lock on the map.

Enhanced Write() to write to all subscribers concurrently.

Also added error logging in the rare instance that there's a map key ID collision.