### PR TITLE
Enable ctrl+c to kill the server

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -435,6 +435,7 @@ func main() {
 	<-sigc
 
 	log.Println("martian: shutting down")
+	os.Exit(0)
 }
 
 func init() {


### PR DESCRIPTION
ctrl+c was not able to kill the server, now after pressing ctrl+x the server exits with 0 code.