### PR TITLE
Export proxy.RoundTripper

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -89,6 +89,11 @@ func NewProxy() *Proxy {
 	return proxy
 }
 
+// GetRoundTripper gets the http.RoundTripper of the proxy.
+func (p *Proxy) GetRoundTripper() http.RoundTripper {
+	return p.roundTripper
+}
+
 // SetRoundTripper sets the http.RoundTripper of the proxy.
 func (p *Proxy) SetRoundTripper(rt http.RoundTripper) {
 	p.roundTripper = rt

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -869,6 +869,11 @@ func TestIntegrationTransparentHTTP(t *testing.T) {
 
 	tr := martiantest.NewTransport()
 	p.SetRoundTripper(tr)
+
+	if got, want := p.GetRoundTripper(), tr; got != want {
+		t.Errorf("proxy.GetRoundTripper: got %v, want %v", got, want)
+	}
+
 	p.SetTimeout(200 * time.Millisecond)
 
 	tm := martiantest.NewModifier()


### PR DESCRIPTION
I would like to be able to wrap the RoundTripper from a proxy and this change simply exports the field.

If there is a preference to use a method like proxy.GetRoundTripper instead of exporting then I'm more than happy to switch to that style of an implementation.