### PR TITLE
Remove listen signal kill (kill -9)

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -430,7 +430,7 @@ func main() {
 	go http.Serve(lAPI, mux)
 
 	sigc := make(chan os.Signal, 1)
-	signal.Notify(sigc, os.Interrupt, os.Kill)
+	signal.Notify(sigc, os.Interrupt)
 
 	<-sigc
 


### PR DESCRIPTION
user namespace program is not able to catch the real kill signal(kill -9)