### PR TITLE
Handle non-base64 encoded har.Content.Text

### DIFF
--- a/har/har_test.go
+++ b/har/har_test.go
@@ -910,3 +910,46 @@ func TestJSONMarshalPostData(t *testing.T) {
 		}
 	}
 }
+
+func TestJSONMarshalContent(t *testing.T) {
+	testCases := []struct {
+		name     string
+		text     []byte
+		encoding string
+	}{
+		{
+			name:     "binary data with base64 encoding",
+			text:     []byte{120, 31, 99, 3},
+			encoding: "base64",
+		},
+		{
+			name: "ascii data with no encoding",
+			text: []byte("hello martian"),
+		},
+		{
+			name:     "ascii data with base64 encoding",
+			text:     []byte("hello martian"),
+			encoding: "base64",
+		},
+	}
+
+	for _, c := range testCases {
+		want := Content{
+			Size:     int64(len(c.text)),
+			MimeType: "application/x-test",
+			Text:     c.text,
+			Encoding: c.encoding,
+		}
+		data, err := json.Marshal(want)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var got Content
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("got %+v, want %+v", got, want)
+		}
+	}
+}


### PR DESCRIPTION
The use of `[]byte` for the `har.Content.Text` field means that go's
json library will always interpret the field as base64 encoded.

The current implementation works out because this library only
generates Content with base64 encoding, and users effectively assume
the `har.Content.Text` field always contains decoded data.

However, this doesn't work if using this library to load a HAR file
generated by another source (i.e. chrome). To address this, this PR:

1. Makes it explicit that the `Text` field only contains decoded data
2. Adds custom JSON marshaler/unmarshaler to automatically encode/decode
data based on the `Encoding` field.