### PR TITLE
Generate RFC 5280 conformant serial numbers

### DIFF
--- a/h2/testing/certs.go
+++ b/h2/testing/certs.go
@@ -93,7 +93,7 @@ func initLocalhostCert(ca *x509.Certificate, caPriv crypto.PrivateKey) (*tls.Cer
 	hasher.Write(pkixpub)
 	keyID := hasher.Sum(nil)
 
-	serial, err := rand.Int(rand.Reader, mitm.MaxSerialNumber)
+	serial, err := mitm.GenerateSerial()
 	if err != nil {
 		return nil, fmt.Errorf("generating serial number: %w", err)
 	}

--- a/mitm/mitm_test.go
+++ b/mitm/mitm_test.go
@@ -132,7 +132,7 @@ func TestCert(t *testing.T) {
 		t.Fatal("x509c: got nil, want *x509.Certificate")
 	}
 
-	if got := x509c.SerialNumber; got.Cmp(MaxSerialNumber) >= 0 {
+	if got := x509c.SerialNumber; got.Cmp(MaxSerialNumber) > 0 {
 		t.Errorf("x509c.SerialNumber: got %v, want <= MaxSerialNumber", got)
 	}
 	if got, want := x509c.Subject.CommonName, "example.com"; got != want {
@@ -201,5 +201,19 @@ func TestCert(t *testing.T) {
 
 	if got, want := x509c.IPAddresses[0], net.ParseIP("10.0.0.1"); !got.Equal(want) {
 		t.Fatalf("x509c.IPAddresses: got %v, want %v", got, want)
+	}
+}
+
+func TestGenerateSerial(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		serial, err := GenerateSerial()
+		if err != nil {
+			t.Fatalf("GenerateSerial(): got %v, want no error", err)
+		}
+		if serial.Cmp(MaxSerialNumber) > 0 {
+			t.Errorf("serial: got %v, want <= MaxSerialNumber", serial)
+		} else if serialBytes := serial.Bytes(); len(serialBytes) == 20 && serialBytes[0]&0x80 != 0 {
+			t.Errorf("serial: got len=20 with MSB set, want MSB unset")
+		}
 	}
 }


### PR DESCRIPTION
Generating RFC 5280 conformant serial numbers is slightly treacherous.
Section 4.1.2.2 dictates that conforming implementations "MUST NOT use
serialNumber values longer than 20 octets". A seemingly obvious way to
pick serials that conform to this requirement is choosing a random int
between [0, 1 << 20*8), which is what the mitm package previously did.
The pitfall here is that the DER encoding of integers uses the MSB to
indicate the sign, so if encoding/asn1 is passed a positive big.Int for
which the encoding has the MSB set it will prefix the encoding with a
0x00 byte. The result of this is that if a serial number is picked that
is exactly 20 bytes, and has its MSB set, it will be encoded as 21
bytes.

The simple solution is to just re-generate the serial if you happen to
pick one which is exactly 20 bytes with the MSB set. Since there are a
number of users of mitm.MaxSerialNumber (both within this project, and
externally), a helper function is added that can be used as a drop-in
replacement for the existing crypto/rand.Int calls.

This came up because we attempted to add a restriction to Go's crypto/x509.CreateCertificate
which limited encoded serial numbers to 20 octets, which broke a number of tests inside of
Google, a handful of which relied on this project. Googlers can see b/229601555 for some
further context here.